### PR TITLE
Disable half-finished mobile mode

### DIFF
--- a/server/src/vodka.js
+++ b/server/src/vodka.js
@@ -62,7 +62,10 @@ import { BINDINGS } from './environment.js'
 import { rootManager } from './rootmanager.js'
 import { setAPIDocCategory } from './documentation.js'
 import { maybeKillSound } from './webaudio.js'
-import { setupMobile, doMobileKeyDown } from './mobile.js'
+// MOBILE WIP: mobile support is half-finished -- the control panel markup in
+// host.html is still commented out, so everything in mobile.js reaches for
+// elements that don't exist and throws. Disabled until that markup comes back.
+// import { setupMobile, doMobileKeyDown } from './mobile.js'
 
 import { getFeatureVector } from './featurevector.js'
 
@@ -247,14 +250,19 @@ function setup() {
 
 	eventQueue.initialize();
 
-	if (Utils.getQSVal('mobile')) {
-		setupMobile();
-	}
+	// MOBILE WIP: see note at the import above.
+	// if (Utils.getQSVal('mobile')) {
+	// 	setupMobile();
+	// }
 
 
+	// Note this object has to keep existing even with mobile off, because
+	// keydispatcher calls setExplodedState unconditionally when you toggle
+	// exploded mode.
 	keyDispatcher.setUiCallbackObject({
 		'setExplodedState': function(exploded) {
-			document.getElementById("mobile_esc").innerText = (exploded) ? 'explode' : 'contract'
+			// MOBILE WIP: see note at the import above.
+			// document.getElementById("mobile_esc").innerText = (exploded) ? 'explode' : 'contract'
 		}});
 
 	// testharness.js needs this
@@ -290,7 +298,9 @@ function setup() {
 		return true;
 	}
 	document.onkeydown = function(e) {
-		doMobileKeyDown(e);
+		// MOBILE WIP: see note at the import above. This ran before the line
+		// below, so when it threw it took the whole keystroke with it.
+		// doMobileKeyDown(e);
 		return doKeydownEvent(e);
 	}
 	let filenameFromQS = getFilenameFromQueryString();


### PR DESCRIPTION
Mobile support was left mid-implementation: the control panel markup in `host.html` is commented out, but `vodka.js` still called into `mobile.js` unconditionally. Every one of those calls reaches for an element that doesn't exist.

Two things this broke in normal desktop use:

- **Enter did nothing.** `document.onkeydown` called `doMobileKeyDown(e)` before `return doKeydownEvent(e)`. On Enter that reached `mobileClearInput()` -> `getElementById('mobile_input').value = ''` -> null. The throw took the whole keystroke with it, so evaluate never ran.
- **Escape / shift-escape did nothing.** `toggleGlobalExplodedMode()` calls `setExplodedState` before `root.toggleRenderMode()`, and that callback touched `#mobile_esc`, also null.

Comments out the four mobile call sites in `vodka.js`, each marked `MOBILE WIP` with a note pointing at the commented-out markup. `mobile.js` itself is untouched, so picking the work back up means restoring the markup and uncommenting these.

The `setUiCallbackObject` object has to keep existing even with mobile off, because keydispatcher calls `setExplodedState` unconditionally, so that one becomes an empty function rather than going away.

Verified in a browser: Enter, shift-escape, plain escape, arrows and backspace all work with no exceptions, and both exploded-mode toggles flip the class correctly.