### PR TITLE
Fix tutorial jumping to a stale panel after paging backwards

### DIFF
--- a/server/src/components/tutorial.jsx
+++ b/server/src/components/tutorial.jsx
@@ -19,7 +19,11 @@ function reducer(state, action) {
         case 'go-to-page': {
             state.stack.push(action.page);
             state.pagesSeen[action.page] = true;
-            state.stackPosition++;
+            // Jump to the page we just pushed, which is the end of the stack --
+            // NOT stackPosition + 1. Those are only the same when you're already
+            // at the end. If you'd paged backwards, incrementing would land on
+            // the next page you'd already seen instead of the new one.
+            state.stackPosition = state.stack.length - 1;
             state.currentPage = state.stack[state.stackPosition];
             state.panelOpen = true;
             return {...state};


### PR DESCRIPTION
If you page backwards in the tutorial and then do something that opens a new panel, the tutorial advances to the next panel you'd already seen instead of jumping to the new one.

The reducer pushed the new page onto the end of the stack but only incremented `stackPosition` by one. Those are the same index only when you're already at the end of the stack.

Concretely, with stack `[Hello, integer, boolean]`: page back to position 0, then insert a string. The new page lands at index 3, but position goes 0 -> 1, so you get the integer panel again.

Sets the position to the end of the stack instead, which is also what the pre-React version did (`setTutorialStackPosition(tutorialPageStack.length - 1)`).

Verified in a browser, including that back/forward still walk the whole stack correctly afterwards and that the Previous/Next buttons appear and disappear at the right ends.