### PR TITLE
[vbftd] Add TODOs for mutability research question

### DIFF
--- a/server/src/builtins/mathbuiltins.js
+++ b/server/src/builtins/mathbuiltins.js
@@ -83,6 +83,10 @@ function createMathBuiltins() {
 			}
 			total += arg.getTypedValue();
 		}
+		// TODO(#264): this comes back mutable, because constructInteger/constructFloat
+		// produce mutable nexes and nothing strips that afterwards. Evaluating a bare
+		// integer gives you an immutable one, so + is inconsistent with it. True of
+		// every builtin that constructs its result, not just this one.
 		let r = foundFloat ? constructFloat(total) : constructInteger(total);
 		return r;
 	}

--- a/server/src/evaluator.js
+++ b/server/src/evaluator.js
@@ -40,6 +40,11 @@ function evaluateNexSafely(nex, executionEnvironment, skipActivation /* TODO: re
 	try {
 		result = nex.evaluate(executionEnvironment);
 
+		// TODO(#265): isMutable is a method, so this is a function reference and
+		// always truthy -- the "Adaptive Mutation" page fires on every evaluation.
+		// The condition is probably also backwards: that page explains that
+		// evaluating a mutable object yields an immutable copy, so it should
+		// likely be nex.isMutable() && !result.isMutable().
 		if (!doTutorial('evaluation')) {
 			if (result.isMutable) doTutorial('mutability');
 		}

--- a/server/src/evaluatorinterface.js
+++ b/server/src/evaluatorinterface.js
@@ -26,6 +26,13 @@ import { manipulator } from './manipulator.js'
 import { evaluateNexSafely } from './evaluator.js'
 
 
+// TODO(#264): this file used to call n.rootLevelPostEvaluationStep() in
+// evaluateAndReplace and evaluateAndKeep, which is what made root-level
+// evaluation results immutable. Those calls were removed in e6a7884 (May 2022)
+// alongside the expectations cleanup, seemingly by accident. As a result only
+// self-evaluating values come back immutable and builtin results stay mutable.
+// Decide whether to restore this before doing anything else with mutability.
+
 /**
  * This method is used for when you want to evaluate the Nex inside a RenderNode
  * and replace the RenderNode with the result of the computation.

--- a/server/src/nex/nex.js
+++ b/server/src/nex/nex.js
@@ -143,6 +143,9 @@ class Nex {
 		return str;
 	}
 
+	// TODO(#264): dead code. This is overridden by 8 nex types to make them
+	// immutable after evaluation, but nothing calls it any more -- see the note
+	// in evaluatorinterface.js.
 	rootLevelPostEvaluationStep() {}
 
 	setOnNextRenderCallback(callback) {

--- a/server/src/nex/valuenex.js
+++ b/server/src/nex/valuenex.js
@@ -48,6 +48,9 @@ class ValueNex extends Nex {
 	}
 
 	evaluate(env) {
+		// TODO(#264): this is currently the ONLY thing in the codebase that makes
+		// an evaluation result immutable, which is why values come back immutable
+		// but builtin results don't.
 		let r = super.evaluate(env);
 		r.setMutable(false);
 		return r;


### PR DESCRIPTION
Comment-only. Adds TODOs pointing at #264 (should evaluation results be immutable?) and #265 ("Adaptive Mutation" popup fires on every evaluation) at the five places in the code where someone would run into them:

- `evaluatorinterface.js` -- where the `rootLevelPostEvaluationStep()` calls were removed
- `nex/nex.js` -- the now-orphaned base method
- `nex/valuenex.js` -- the only remaining live enforcement
- `builtins/mathbuiltins.js` -- `$plus`, the case that surfaced it
- `evaluator.js` -- the popup trigger

No behavior change.