### PR TITLE
[vbftd] Fix package imports (hang + masked error), fix mutability popup

### DIFF
--- a/server/src/evaluator.js
+++ b/server/src/evaluator.js
@@ -40,13 +40,17 @@ function evaluateNexSafely(nex, executionEnvironment, skipActivation /* TODO: re
 	try {
 		result = nex.evaluate(executionEnvironment);
 
-		// TODO(#265): isMutable is a method, so this is a function reference and
-		// always truthy -- the "Adaptive Mutation" page fires on every evaluation.
-		// The condition is probably also backwards: that page explains that
-		// evaluating a mutable object yields an immutable copy, so it should
-		// likely be nex.isMutable() && !result.isMutable().
+		// The "Adaptive Mutation" tutorial page explains that evaluating a mutable
+		// object gives you back an immutable copy, so only show it when that's
+		// actually what just happened. Note isMutable is a method -- this used to
+		// test the bare reference, which is always truthy, so the page fired on
+		// every single evaluation. See TODO(#264) elsewhere: builtin results are
+		// currently still mutable, which narrows when this can fire.
 		if (!doTutorial('evaluation')) {
-			if (result.isMutable) doTutorial('mutability');
+			if (result && nex.isMutable && result.isMutable
+					&& nex.isMutable() && !result.isMutable()) {
+				doTutorial('mutability');
+			}
 		}
 	} catch (e) {
 		if (Utils.isError(e)) {

--- a/server/src/paramparser.js
+++ b/server/src/paramparser.js
@@ -108,8 +108,21 @@ class ParamParser {
       if (s == "") return null;
     }
     let groups = s.match(/([a-zA-Z0-9_-]*[a-zA-Z0-9-])(.*)/);
-    let typeString = groups[2];
-    s = groups[1];
+    let typeString;
+    if (groups) {
+      typeString = groups[2];
+      s = groups[1];
+    } else {
+      // No identifier characters at all, so the whole token is a bare type code
+      // with no name. That's how a return value is declared: parseString() spots
+      // a leading type code and marks it with a backslash, so "#% lst()" means
+      // "returns an integer or float, takes a container called lst". Keep the
+      // backslash as the name, because parse() routes on it and lambda.js strips
+      // it back off when rebuilding the lambda's display text.
+      let isReturnValue = (s.charAt(0) == "\\");
+      typeString = isReturnValue ? s.substring(1) : s;
+      s = isReturnValue ? "\\" : "";
+    }
 
     let typeValidator = this.getTypeValidator(typeString);
     if (typeString == ",") {

--- a/server/src/servercommunication.js
+++ b/server/src/servercommunication.js
@@ -150,20 +150,47 @@ function parseReturnPayload(data, callback) {
 	try {
 		result = parse(data);
 	} catch (e) {
-		if (!Utils.isError(e)) {
-			result = constructFatalError(
-`PEG PARSER PERROR
+		result = describeParseFailure(e);
+	}
+	// Always call back, even on failure. This used to be able to throw on its
+	// way out of the catch block (see below), and because the callback never
+	// ran, anything waiting on a deferred value -- like the import builtin --
+	// would just spin forever with no indication of what went wrong.
+	callback(result);
+}
+
+// Turns whatever came out of parse() into a nex we can hand back.
+//
+// Not every failure is a PEG syntax error. Bugs inside the parser's own
+// support code throw ordinary TypeErrors, which have no .location, and the
+// old version of this assumed the PEG shape unconditionally -- so a real bug
+// got replaced by "Cannot read properties of undefined (reading 'start')",
+// hiding the thing you actually needed to see.
+function describeParseFailure(e) {
+	if (Utils.isError(e)) {
+		// already a vodka error, pass it along rather than losing it
+		return e;
+	}
+	if (e && e.location && e.location.start) {
+		let expected = (e.expected && e.expected[0] && e.expected[0].type)
+				? e.expected[0].type
+				: '(unknown)';
+		return constructFatalError(
+`PEG PARSER ERROR
 full error message follows:
 ${e.name}
 ${e.message}
 line: ${e.location.start.line}
 col: ${e.location.start.column}
 found: "${e.found}"
-expected: ${e.expected[0].type}
+expected: ${expected}
 ` + e);
-		}
 	}
-	callback(result);
+	return constructFatalError(
+`PARSER ERROR (not a syntax error -- this is probably a bug in vodka)
+${e && e.name}
+${e && e.message}
+${(e && e.stack) ? e.stack : ''}`);
 }
 
 function evaluatePackage(nex) {


### PR DESCRIPTION
Fixes the forever-spinner and `Cannot read properties of undefined (reading 'start')` when evaluating a package. Also closes #265.

## Root cause: return-value param syntax stopped parsing

A lambda's param string can start with a bare type code declaring the **return** type -- `"#% lst()"` means "returns an integer or float, takes a container called `lst`". `parseString()` still detects that and marks it with a backslash, and `parse()` still routes it to `returnValue`.

But the param tokenizer rewrite in `0052187` (July 2023) replaced `getTypeCode()` with

```js
let groups = s.match(/([a-zA-Z0-9_-]*[a-zA-Z0-9-])(.*)/);
let typeString = groups[2];
```

That regex needs at least one identifier character, so a bare type code returns `null` and `groups[2]` throws a `TypeError`. Return values are still a live feature (`command.js:338` uses them for contract checking, `lambda.js:182` round-trips the marker), so this looks like a regression rather than an intentional removal.

**8 of the 26 shipped packages were unloadable** because of it: `math-functions`, `list-functions`, `style-functions`, `table-functions`, `traversal-functions`, `writing-functions`, `debugging-functions`, `animation-functions`. `color-functions` imports `math-functions`, which is how this surfaced.

## Why it presented as a hang

`parseReturnPayload()` assumed any exception was a PEG `SyntaxError` and read `e.location.start.line`. A `TypeError` has no `.location`, so the handler itself threw -- replacing the real error with a confusing one, and skipping `callback()` entirely. The `import` builtin's deferred value then never resolved, so it spun forever.

Now it distinguishes vodka errors, PEG syntax errors, and everything else, and always calls back. Previously a vodka error also left `result` as `null`, which `evaluatePackage()` would then dereference.

## Mutability popup (#265)

`result.isMutable` was a method reference, always truthy, so "Adaptive Mutation" fired on every evaluation -- including cases where it told the user something untrue. Now checks that the input was mutable and the result isn't, which is what the page actually explains.

## Verified

- all 24 real packages parse (the 2 remaining failures are `raw-file-for-testing` and `unparsable-file-for-testing`, which are meant to be unparsable)
- 14/14 packages import cleanly in the browser with no console errors, including the 8 that were broken
- help-system suites still pass (17/17, 7/7), tutorial navigation passes, keystroke suite passes, REPL unaffected