### PR TITLE
[4/17] Restore the twelve event queue unit tests that esbuild deleted

### DIFF
--- a/server/src/tests/unittests.js
+++ b/server/src/tests/unittests.js
@@ -20,8 +20,34 @@ import { eventQueueDispatcher } from '../eventqueuedispatcher.js'
 
 eventQueue.initialize();
 
+// Looked up in a table rather than assembled into an eval string. A bundler
+// can't see a name built at runtime, so with eval the TEST_ functions below
+// had no visible callers and esbuild stripped every one of them out -- the
+// tests all died with "TEST_<name> is not defined" against a bundle that
+// genuinely didn't contain them. Referencing them here keeps them alive.
+function getTests() {
+	return {
+		'eventqueue_events_alertanimation': TEST_eventqueue_events_alertanimation,
+		'eventqueue_events_doclickhandleraction': TEST_eventqueue_events_doclickhandleraction,
+		'eventqueue_events_dokeyinput': TEST_eventqueue_events_dokeyinput,
+		'eventqueue_events_gc': TEST_eventqueue_events_gc,
+		'eventqueue_events_renderonlydirty': TEST_eventqueue_events_renderonlydirty,
+		'eventqueue_events_toplevelrender': TEST_eventqueue_events_toplevelrender,
+		'eventqueue_events_importanttoplevelrender': TEST_eventqueue_events_importanttoplevelrender,
+		'eventqueue_priority_inverseordering': TEST_eventqueue_priority_inverseordering,
+		'eventqueue_priority_addedwhiledequeueing': TEST_eventqueue_priority_addedwhiledequeueing,
+		'eventqueue_priority_inverseordering2': TEST_eventqueue_priority_inverseordering2,
+		'eventqueue_priority_normalandimportantrender': TEST_eventqueue_priority_normalandimportantrender,
+		'eventqueue_deduping': TEST_eventqueue_deduping,
+	};
+}
+
 export function runTest(testname) {
-	eval('TEST_' + testname + '();');
+	let test = getTests()[testname];
+	if (!test) {
+		throw new Error('no such unit test: ' + testname);
+	}
+	test();
 }
 
 function assertEqual(a, b) {


### PR DESCRIPTION
runTest reached its test bodies through eval('TEST_' + testname + '();').
A bundler can't see a name assembled at runtime, so esbuild concluded all
twelve TEST_ functions were dead code and dropped them; runTest survived and
called into functions that no longer existed in the bundle. Every one of them
died with "TEST_<name> is not defined", and esbuild had been warning about the
direct eval by file and line the whole time.

Introduced by eb6e018, the parcel to esbuild migration. Parcel kept them.

A lookup table makes the reference static, so they survive bundling and the
warning goes away. Unknown names now throw instead of producing a
ReferenceError from inside eval.

These are the only tests covering the event queue, so having them dead while
changing that queue was the wrong way round.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 3 of 5. Base: `pr-test-harness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
