### PR TITLE
[5/17] Make the five stdlib tests that never waited actually wait

### DIFF
--- a/testing/alltests/unit_color.js
+++ b/testing/alltests/unit_color.js
@@ -91,6 +91,8 @@ testactions.push({type:'keyup',code:'ShiftRight'});
 testactions.push({type:'keydown',code:'Enter'});
 testactions.push({type:'keyup',code:'Enter'});
 
+testactions.push({type:'pause',length:500});
+
 const experiment_flags = {
 "DISABLE_ALERT_ANIMATIONS":true,
 "MAX_RENDER_DEPTH":100,

--- a/testing/alltests/unit_math.js
+++ b/testing/alltests/unit_math.js
@@ -89,6 +89,8 @@ testactions.push({type:'keyup',code:'ShiftRight'});
 testactions.push({type:'keydown',code:'Enter'});
 testactions.push({type:'keyup',code:'Enter'});
 
+testactions.push({type:'pause',length:500});
+
 const experiment_flags = {
 "DISABLE_ALERT_ANIMATIONS":true,
 "MAX_RENDER_DEPTH":100,

--- a/testing/alltests/unit_table.js
+++ b/testing/alltests/unit_table.js
@@ -93,6 +93,8 @@ testactions.push({type:'keyup',code:'ShiftRight'});
 testactions.push({type:'keydown',code:'Enter'});
 testactions.push({type:'keyup',code:'Enter'});
 
+testactions.push({type:'pause',length:3000});
+
 const experiment_flags = {
 "DISABLE_ALERT_ANIMATIONS":true,
 "MAX_RENDER_DEPTH":100,

--- a/testing/alltests/unit_template.js
+++ b/testing/alltests/unit_template.js
@@ -93,6 +93,8 @@ testactions.push({type:'keyup',code:'ShiftRight'});
 testactions.push({type:'keydown',code:'Enter'});
 testactions.push({type:'keyup',code:'Enter'});
 
+testactions.push({type:'pause',length:500});
+
 const experiment_flags = {
 "DISABLE_ALERT_ANIMATIONS":true,
 "MAX_RENDER_DEPTH":100,

--- a/testing/alltests/unit_traversal.js
+++ b/testing/alltests/unit_traversal.js
@@ -101,6 +101,8 @@ testactions.push({type:'keyup',code:'ShiftRight'});
 testactions.push({type:'keydown',code:'Enter'});
 testactions.push({type:'keyup',code:'Enter'});
 
+testactions.push({type:'pause',length:500});
+
 const experiment_flags = {
 "DISABLE_ALERT_ANIMATIONS":true,
 "MAX_RENDER_DEPTH":100,


### PR DESCRIPTION
unit_table, unit_traversal, unit_color, unit_math and unit_template had no
pause at all, so the screenshot fired while the file load was still in flight
and they captured a spinner instead of a result. Every stdlib test without a
pause was failing and both that had one were passing, with no exceptions.

They looked like a deferred-machinery bug for most of a day. They were not --
the app was fine, nothing waited for it. It worked by hand because human
reaction time covers the load, and it worked in headed mode because that
sleeps a quarter second per action.

unit_table needs longer than the others because table-functions pulls in a
deeper chain of imports.

All five now reach "all tests passed", which is the string these tests exist
to assert. That makes six of the eight stdlib packages actually verified;
unit_layout and unit_style use @vis-verify, which renders comparisons for a
human to look at and asserts nothing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 4 of 5. Base: `pr-restore-eventqueue-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
