### PR TITLE
[6/17] Fix the broken golden links in test results, and add a mac/linux comparison

### DIFF
--- a/testing/onetestresult.tmpl
+++ b/testing/onetestresult.tmpl
@@ -208,7 +208,7 @@
 									</div>
 									<div class="outimg" onclick="togglestyle(this);">
 										<div class="outimgname">golden</div>
-										<img src="./{{../test}}_GOLDEN_{{diff_type}}.png">
+										<img src="./goldens/{{platform}}/{{../test}}_GOLDEN_{{diff_type}}.png">
 									</div>
 									<div class="outimg" onclick="togglestyle(this);">
 										<div class="outimgname">diff</div>

--- a/testing/parsetestoutput.js
+++ b/testing/parsetestoutput.js
@@ -20,6 +20,11 @@ var fs = require("fs");
 var glob = require("glob")
 var path = require("path")
 
+// Goldens live under goldens/<platform>/ so the two platforms' sets can
+// coexist; see platform.sh. The per-test html sits in the test directory, so
+// the link from it is relative to that.
+const PLATFORM = (process.platform == 'darwin') ? 'mac' : 'linux';
+
 function tpath(output_suffix) {
 	return `./alltests/${basename}/${basename}${output_suffix}`;
 }
@@ -40,6 +45,7 @@ function testDiff(type) {
 	let goldenUpdateExtension = (type == 'EXPLODED' ? '-e' : '-n');
 	return {
 		'test': basename,
+		'platform': PLATFORM,
 		'diff_type': type,
 		'regenerate_golden_ext': goldenUpdateExtension,
 		'regenerated_golden': regeneratedGolden,


### PR DESCRIPTION
The goldens moved to goldens/<platform>/ but onetestresult.tmpl still pointed
at the old flat path, so every "golden" image in the per-test results pages
was a broken link. Output and diff images were unaffected, which is why it
wasn't obvious -- you got two of three panels.

comparegoldens.sh scores each linux golden against its mac counterpart and
writes a page ranked worst-first, so a whole set can be triaged by looking at
the top rather than opening 746 pairs.

It downscales and blurs before comparing, because the two sets were captured
on different machines and glyph antialiasing differs on every single test --
a raw pixel count says "different" for all of them and buries the ones that
matter. The score ranks, it doesn't decide: measured on this corpus the pure
antialiasing noise reaches 0.032, which overlaps where real differences
start, so there is no threshold that separates them cleanly.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 5 of 5. Base: `pr-stdlib-test-waits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
