### PR TITLE
[3/14] Don't build a debug string on every command evaluation

### DIFF
--- a/server/src/nex/command.js
+++ b/server/src/nex/command.js
@@ -25,7 +25,7 @@ import { constructFatalError, throwOOM } from './eerror.js'
 import { Closure } from './closure.js'
 import { ContextType } from '../contexttype.js'
 import { evaluateNexSafely } from '../evaluator.js'
-import { RENDER_FLAG_SHALLOW, RENDER_FLAG_EXPLODED } from '../globalconstants.js'
+import { RENDER_FLAG_SHALLOW, RENDER_FLAG_EXPLODED, CONSOLE_DEBUG } from '../globalconstants.js'
 import { Editor } from '../editors.js'
 import { experiments } from '../globalappflags.js'
 import { doTutorial } from '../help.js'
@@ -332,13 +332,15 @@ class Command extends NexContainer {
 
 		let argEvaluator = closure.getArgEvaluator(cmdname, argContainer, executionEnv);
 
+		const debugStr = CONSOLE_DEBUG ? this.debugString() : "";
+
 		return new RunInfo(
 			closure,
 			cmdname,
 			closure.getReturnValueParam(),
 			argContainer,
 			argEvaluator,
-			this.debugString(),
+			debugStr,
 			this.skipAlert,
 			this.getAllTags(),
 			packageName);


### PR DESCRIPTION
createRunInfo passed this.debugString() into every RunInfo it built. That
string is only ever read when console debugging is on, but it was constructed
unconditionally -- and debugString walks the whole subtree, so evaluating a
deeply nested expression rebuilt a description of it at every level. The cost
grew quadratically with nesting depth on the hot path of the evaluator.

Now it's built only when CONSOLE_DEBUG is set, and an empty string otherwise.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 8 of 15. Base: `pr-linux-setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
