### PR TITLE
[4/14] Show builtin aliases in the API reference, and fix the union return type crash

### DIFF
--- a/server/src/builtins/basicbuiltins.js
+++ b/server/src/builtins/basicbuiltins.js
@@ -56,7 +56,7 @@ function createBasicBuiltins() {
 			}
 			return lst.getFirstChild();
 		},
-		'Returns the first element of |list without altering |list. Aliases: head, first.'
+		'Returns the first element of |list without altering |list.'
 	);
 	Builtin.aliasBuiltin('head', 'car');
 	Builtin.aliasBuiltin('first', 'car');
@@ -74,7 +74,7 @@ function createBasicBuiltins() {
 			c.getChildrenForCdr(newOne);
 			return newOne;
 		},
-		'Returns a copy of |list containing all elements of |list except the first one. Aliases: tail, rest.'
+		'Returns a copy of |list containing all elements of |list except the first one.'
 	);
 	Builtin.aliasBuiltin('tail', 'cdr');
 	Builtin.aliasBuiltin('rest', 'cdr');
@@ -90,7 +90,7 @@ function createBasicBuiltins() {
 			lst.setChildrenForCons(nex, newOne);
 			return newOne;
 		},
-		'Returns a new list created by prepending |nex to a copy of |list. Aliases: push, push-into.'
+		'Returns a new list created by prepending |nex to a copy of |list.'
 	);
 	Builtin.aliasBuiltin('push', 'cons');
 	Builtin.aliasBuiltin('push into', 'cons');
@@ -108,7 +108,7 @@ function createBasicBuiltins() {
 			c.removeChild(c.getChildAt(0));
 			return r;
 		},
-		'Removes the first element of |list, destructively altering list, and returns the removed element. Aliases: hard-car, hard-first, hard-head.'
+		'Removes the first element of |list, destructively altering list, and returns the removed element.'
 	);
 	Builtin.aliasBuiltin('hard-car', 'chop');
 	Builtin.aliasBuiltin('hard-first', 'chop');
@@ -126,7 +126,7 @@ function createBasicBuiltins() {
 			c.removeChild(c.getChildAt(0));
 			return c;
 		},
-		'Destructively removes the first element of |list, and returns the altered |list. Aliases: hard-cdr, hard-tail, hard-rest.'
+		'Destructively removes the first element of |list, and returns the altered |list.'
 	);
 	Builtin.aliasBuiltin('hard-cdr', 'chomp');
 	Builtin.aliasBuiltin('hard-rest', 'chomp');
@@ -141,7 +141,7 @@ function createBasicBuiltins() {
 			lst.prependChild(env.lb('nex'));
 			return lst;
 		},
-		'Destructively alters |list by prepending |nex to it. Aliases: hard-cons, hard-push, hard-push into.'
+		'Destructively alters |list by prepending |nex to it.'
 	);
 	Builtin.aliasBuiltin('hard-cons', 'cram');
 	Builtin.aliasBuiltin('hard-push', 'cram');

--- a/server/src/builtins/environmentbuiltins.js
+++ b/server/src/builtins/environmentbuiltins.js
@@ -55,7 +55,7 @@ function createEnvironmentBuiltins() {
 			}
 			return name;
 		},
-		'Binds a new global variable named |name to |nex. Aliases: bind to'
+		'Binds a new global variable named |name to |nex.'
 	);
 	Builtin.aliasBuiltin('bind to', 'bind');
 
@@ -136,7 +136,7 @@ function createEnvironmentBuiltins() {
 			}
 			return rhs;
 		},
-		'Binds the variable |name to |nex in the current closure\'s local scope. Aliases: let be'
+		'Binds the variable |name to |nex in the current closure\'s local scope.'
 	);
 	Builtin.aliasBuiltin('let be', 'let');
 

--- a/server/src/builtins/iterationbuiltins.js
+++ b/server/src/builtins/iterationbuiltins.js
@@ -65,7 +65,7 @@ function createIterationBuiltins() {
 			}
 			return resultList;
 		},
-		'Returns a new list containing only the elements of |list for which |func calls true when it is called on that element. Aliases: filter with'
+		'Returns a new list containing only the elements of |list for which |func calls true when it is called on that element.'
 	);
 
 	Builtin.aliasBuiltin('filter with', 'filter');
@@ -102,7 +102,7 @@ function createIterationBuiltins() {
 			}
 			return resultList;
 		},
-		'Goes through all the elements in |list and replaces each one with the result of calling |func on that element. Aliases: map with'
+		'Goes through all the elements in |list and replaces each one with the result of calling |func on that element.'
 	);
 
 	Builtin.aliasBuiltin('map with', 'map');
@@ -136,7 +136,7 @@ function createIterationBuiltins() {
 			}
 			return p;
 		},
-		'Progressively updates a value, starting with |startvalue, by calling |func on each element in |list, passing in 1. the list element and 2. the progressively updated value, returning the final updated value. Aliases: reduce with, reduce with starting'
+		'Progressively updates a value, starting with |startvalue, by calling |func on each element in |list, passing in 1. the list element and 2. the progressively updated value, returning the final updated value.'
 	);
 
 	Builtin.aliasBuiltin('reduce with', 'reduce');
@@ -257,7 +257,7 @@ function createIterationBuiltins() {
 			}
 			return bodyresult ? bodyresult : constructNil();
 		},
-		`Classic "for loop". First |start is evaluated, then |test. If |test returns true, |body and |inc are evaluated, and then we go back to |test. Alias: starting-with while do then-with.`
+		`Classic "for loop". First |start is evaluated, then |test. If |test returns true, |body and |inc are evaluated, and then we go back to |test.`
 	)
 
 	Builtin.aliasBuiltin('starting-with while do then-with', 'for-loop');

--- a/server/src/builtins/logicbuiltins.js
+++ b/server/src/builtins/logicbuiltins.js
@@ -58,7 +58,7 @@ function createLogicBuiltins() {
 			}
 			return constructNil();
 		},
-		'Returns the first argument that does not evaluate to nil, ignoring the rest. Alias: case.'
+		'Returns the first argument that does not evaluate to nil, ignoring the rest.'
 	)
 
 	Builtin.aliasBuiltin('case', 'first-non-nil');
@@ -89,7 +89,7 @@ function createLogicBuiltins() {
 				return iffalseresult;
 			}
 		},
-		'Evalutes |cond, and if it is true, return |iftrue, otherwise return |iffalse. If |iffalse is not provided, a Nil is returned if |cond is false. Alias: if.'
+		'Evalutes |cond, and if it is true, return |iftrue, otherwise return |iffalse. If |iffalse is not provided, a Nil is returned if |cond is false.'
 	)
 	Builtin.aliasBuiltin('if', 'if then else');
 

--- a/server/src/commandfunctions.js
+++ b/server/src/commandfunctions.js
@@ -179,7 +179,19 @@ function executeRunInfo(runInfo, executionEnv) {
 	let result = runCommand(runInfo, executionEnv);
 
 	if (runInfo.expectedReturnType != null && !Utils.isFatalError(result)) {
-		let typeChecksOut = ArgEvaluator.ARG_VALIDATORS[runInfo.expectedReturnType.type](result);
+		// A type can be a union -- '#%' parses to 'Integer|Float' -- so split it
+		// the way checkType does for parameters (argevaluator.js). Looking up the
+		// whole union as one key finds nothing and calls undefined as a function,
+		// which is a JS TypeError that escapes the evaluator entirely.
+		let allowedTypes = runInfo.expectedReturnType.type.split('|');
+		let typeChecksOut = false;
+		for (let i = 0; i < allowedTypes.length; i++) {
+			let validator = ArgEvaluator.ARG_VALIDATORS[allowedTypes[i]];
+			if (validator && validator(result)) {
+				typeChecksOut = true;
+				break;
+			}
+		}
 		if (!typeChecksOut) {
 			result = constructFatalError(`${runInfo.cmdname.get()}: should return ${runInfo.expectedReturnType.type} but returned ${result.getTypeName()}`);
 		}

--- a/server/src/documentation.js
+++ b/server/src/documentation.js
@@ -26,6 +26,11 @@ let apiDocCategory = '';
 
 let docs = {};
 let docorder = [];
+// canonical builtin name -> [alias, ...]. Kept separate from docs{} rather than
+// stored on the doc item, because aliasBuiltin() runs after the builtin it
+// aliases has already been documented, and not necessarily in the same
+// category block.
+let aliases = {};
 
 function setAPIDocCategory(str) {
 	apiDocCategory = str;
@@ -39,6 +44,13 @@ function documentBuiltin(name, params, info) {
 		info:info,
 		params:params
 	})
+}
+
+function documentAlias(aliasName, boundName) {
+	if (!aliases[boundName]) {
+		aliases[boundName] = [];
+	}
+	aliases[boundName].push(aliasName);
 }
 
 // Doc strings mark up hotkeys/argument names by prefixing them with a pipe,
@@ -68,7 +80,7 @@ function parseInfoString(info) {
 }
 
 // Returns the whole API reference as data, in the order the categories were
-// declared: [ { category, items: [ { name, params, infoPieces } ] } ]
+// declared: [ { category, items: [ { name, params, aliases, infoPieces } ] } ]
 function getDocs() {
 	return docorder.map(function(category) {
 		return {
@@ -77,6 +89,7 @@ function getDocs() {
 				return {
 					name: item.name,
 					params: item.params,
+					aliases: aliases[item.name] ? aliases[item.name].slice() : [],
 					infoPieces: parseInfoString(item.info)
 				};
 			})
@@ -84,4 +97,4 @@ function getDocs() {
 	});
 }
 
-export { setAPIDocCategory, documentBuiltin, getDocs }
+export { setAPIDocCategory, documentBuiltin, documentAlias, getDocs }

--- a/server/src/nex/builtin.js
+++ b/server/src/nex/builtin.js
@@ -20,7 +20,7 @@ import { ParamParser } from '../paramparser.js'
 import { BUILTINS } from '../environment.js'
 import { PERFORMANCE_MONITOR, perfmon } from '../perfmon.js'
 import { experiments } from '../globalappflags.js'
-import { documentBuiltin } from '../documentation.js'
+import { documentBuiltin, documentAlias } from '../documentation.js'
 import { heap, HeapString } from '../heap.js'
 import { throwOOM } from './eerror.js'
 
@@ -142,9 +142,9 @@ class Builtin extends Lambda {
 	}
 
 	static aliasBuiltin(aliasName, boundName) {
-		// temporarily a no-op because this messes up autocomplete
 		let bound = BUILTINS.lookupBinding(boundName);
 		Builtin.bindBuiltinObject(aliasName, bound);
+		documentAlias(aliasName, boundName);
 	}
 
 	static bindBuiltinObject(name, nex) {


### PR DESCRIPTION
Aliases were registered but never surfaced, so the reference listed a name
with no indication that other names reached the same function. They're now
attached to the canonical entry and rendered under it. Several docstrings had
hand-written "alias:" text describing the same thing; that's removed, since it
had to be kept in sync by hand and now duplicates the generated list.

Separately, in commandfunctions.js: a return type can be a union -- '#%'
parses to 'Integer|Float' -- but the return type check looked the whole union
up in ARG_VALIDATORS as a single key, found nothing, and called undefined as a
function. That's a JS TypeError, so it escaped the evaluator entirely rather
than surfacing as a vodka error. It now splits on '|' the way checkType
already does for parameters.

math:sum was hitting this, which took the math-tests package down with it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 9 of 15. Base: `pr-command-debug-perf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
