### PR TITLE
[5/14] Add section navigation to the API reference and show the selected help tab

### DIFF
--- a/server/src/components/api_reference_panel.jsx
+++ b/server/src/components/api_reference_panel.jsx
@@ -11,6 +11,42 @@ function docs() {
     return cachedDocs;
 }
 
+// Category names are author-written strings, so make a DOM-safe id out of them.
+function categoryId(category) {
+    return 'apicat-' + category.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+const TOP_ID = 'apinav-top';
+
+// The reference is long and the panel isn't its own scroll container, so jumps
+// have to go through the document. No smooth behavior -- these are jumps.
+function jumpToId(id) {
+    const el = document.getElementById(id);
+    if (el) {
+        el.scrollIntoView({block: 'start'});
+    }
+}
+
+const BackToTop = () => (
+    <p className="infoline">
+        <span className="apibacktotop" onClick={() => jumpToId(TOP_ID)}>back to top</span>
+    </p>
+);
+
+const SectionNav = ({groups}) => {
+    const jumpTo = (category) => jumpToId(categoryId(category));
+    return (
+        <div className="apinav" id={TOP_ID}>
+            {groups.map((group) => (
+                <span
+                    key={`nav-${group.category}`}
+                    className="apinavitem"
+                    onClick={() => jumpTo(group.category)}>{group.category}</span>
+            ))}
+        </div>
+    );
+};
+
 const InfoLine = ({pieces}) => {
     return (
         <p className="infoline infoindent">
@@ -34,6 +70,13 @@ const DocItem = ({item}) => {
                             <span key={`a${i}`} className="infohotkey">{param}</span>)}
                    </p>)
                 : <></>}
+            {item.aliases.length > 0
+                ? (<p className="infoline infoindent">
+                        aliases:&nbsp;
+                        {item.aliases.map((alias, i) =>
+                            <span key={`al${i}`} className="infohotkey">{alias}</span>)}
+                   </p>)
+                : <></>}
             <InfoLine pieces={item.infoPieces} />
             <p className="infospacer"></p>
             <p className="infospacer"></p>
@@ -42,11 +85,14 @@ const DocItem = ({item}) => {
 };
 
 const ApiReferencePanel = () => {
+    const groups = docs();
     return (
         <div className="infopanel" id="fullapireference">
-            {docs().map((group) => (
+            <SectionNav groups={groups} />
+            {groups.map((group) => (
                 <div key={group.category}>
-                    <p className="infotitle">{group.category}</p>
+                    <p className="infotitle" id={categoryId(group.category)}>{group.category}</p>
+                    <BackToTop />
                     <p className="infospacer"></p>
                     {group.items.map((item, i) =>
                         <DocItem key={`${group.category}-${i}`} item={item} />)}

--- a/server/src/components/app.jsx
+++ b/server/src/components/app.jsx
@@ -72,6 +72,18 @@ const App = () => {
         }
     }
 
+    // Which tab the top menu should show as selected. The panel constants and
+    // the menu constants are separate enumerations, so map explicitly rather
+    // than relying on them happening to line up.
+    const selectedMenuChoice = () => {
+        switch(panel) {
+            case API_REFERENCE_PANEL: return FULL_API_REFERENCE;
+            case BASIC_USAGE_PANEL:   return QUICK_REFERENCE;
+            case WELCOME_PANEL:
+            default:                  return WELCOME;
+        }
+    }
+
     const displayPanel = () => {
         switch(panel) {
             case API_REFERENCE_PANEL:
@@ -105,7 +117,9 @@ const App = () => {
                         case SHOWING_PANELS:
                             return (
                                 <>
-                                <TopMenu onMenuChange={handleMenuChange}/>
+                                <TopMenu
+                                    selectedMenuChoice={selectedMenuChoice()}
+                                    onMenuChange={handleMenuChange}/>
                                 {displayPanel()}
                                 </>
                             );

--- a/server/src/components/basic_usage_panel.jsx
+++ b/server/src/components/basic_usage_panel.jsx
@@ -77,6 +77,10 @@ const BasicUsagePanel = () => {
         <p className="infospacer"></p>
         <p className="infoline"><span className="infohotkey">shift-space</span>toggles direction of current container (horizontal/vertical)</p>
         <p className="infospacer"></p>
+        <p className="infoline"><span className="infohotkey">\\</span>collapse or expand the selected container (containers only)</p>
+        <p className="infospacer"></p>
+        <p className="infoline"><span className="infohotkey"><span className="optionkey">{OPTION_KEY}</span>-shift-delete</span>"unroll" the selected container -- dissolve it, leaving its children behind in its place (containers only)</p>
+        <p className="infospacer"></p>
         <p className="infoline"><span className="infohotkey">shift-escape</span>toggle exploded/normal modes for entire document</p>
         <p className="infoline"><span className="infohotkey">shift-alt-escape</span>toggle exploded/normal modes for selected object (and its children)</p>
         <p className="infospacer"></p>
@@ -119,6 +123,29 @@ const BasicUsagePanel = () => {
         <p className="infoline">Multiple parameter specifiers can be combined, for example <span className="infohotkey">_n#%...</span>,<span className="infohotkey">n()?</span></p>
         <p className="infoline"><span className="infohotkey">%#</span>either float or integer types allowed, others are not allowed (any type codes can be combined)</p>
         <p className="infoline">If no type is specified, any type is allowed.</p>
+        <p className="infospacer"></p>
+        <p className="infosubheader">Wavetables (sound objects):</p>
+        <p className="infolinemargin">A wavetable holds a sound. Insert one with <span className="infohotkey">_</span>, then press <span className="infohotkey">delete</span> to enter edit mode, same as any other object.</p>
+        <p className="infoline"><span className="infohotkey">enter</span>audition (play) the whole wave. Note that for wavetables this plays the sound rather than evaluating the object.</p>
+        <p className="infospacer"></p>
+        <p className="infosubheader">In wavetable editor:</p>
+        <p className="infoline"><span className="infohotkey">0</span>audition the whole wave</p>
+        <p className="infoline"><span className="infohotkey">1</span>through <span className="infohotkey">9</span>audition that numbered section (does nothing until you have added markers)</p>
+        <p className="infoline"><span className="infohotkey">v</span>add a marker at the center sample</p>
+        <p className="infolinemargin">Markers divide the wave into sections, so N markers give you N+1 sections. Sections are auditioned by number starting at 1, even though the marker buttons themselves are labelled with letters.</p>
+        <p className="infospacer"></p>
+        <p className="infosubheader">Wavetable mouse controls:</p>
+        <p className="infoline">drag on the waveform to zoom in and out in time (drag whichever direction is bigger, horizontal or vertical)</p>
+        <p className="infoline">shift-drag to zoom the amplitude (vertical scale) instead</p>
+        <p className="infoline">while in edit mode, clicking sets the center sample and dragging scrolls the view</p>
+        <p className="infospacer"></p>
+        <p className="infosubheader">Wavetable on-screen controls:</p>
+        <p className="infolinemargin">These are the small buttons in the strip above the waveform, and they are mouse-only.</p>
+        <p className="infoline"><span className="infohotkey">1.5 secs</span>the length readout. Click it to cycle the timebase: notenum, secs, hz, beats, samps</p>
+        <p className="infoline"><span className="infohotkey">* rec</span>start recording audio into this wavetable</p>
+        <p className="infoline"><span className="infohotkey">[] stop</span>stop recording</p>
+        <p className="infoline"><span className="infohotkey">v</span>add a marker (same as pressing v)</p>
+        <p className="infoline"><span className="infohotkey">a</span><span className="infohotkey">b</span><span className="infohotkey">c</span>one button per marker. Click one to delete that marker.</p>
         <p className="infospacer"></p>
         <p className="infosubheader">In tag editor:</p>
         <p className="infolinemargin">Any object can be tagged. Any character including spaces can be used in a tag.</p>

--- a/server/src/components/menubutton.jsx
+++ b/server/src/components/menubutton.jsx
@@ -1,11 +1,13 @@
 
-const MenuButton = ({text, onMenuButtonClick}) => {
+const MenuButton = ({text, selected, onMenuButtonClick}) => {
     const handleClick = () => {
         onMenuButtonClick();
     }
 
+    const className = 'helpmenuitem helpbutton' + (selected ? ' helpmenuitemselected' : '');
+
     return (
-        <div className="helpmenuitem helpbutton" onClick={handleClick}>{text}</div>
+        <div className={className} onClick={handleClick}>{text}</div>
     );
 };
 

--- a/server/src/components/topmenu.jsx
+++ b/server/src/components/topmenu.jsx
@@ -1,20 +1,25 @@
 import MenuButton from './menubutton.jsx'
 import { WELCOME, QUICK_REFERENCE, FULL_API_REFERENCE, START_TUTORIAL, CLOSE_HELP } from './menu_constants.js';
 
-const TopMenu = ({onMenuChange}) => {
+// Only the first three are tabs -- the last two are actions, so they never
+// show as selected.
+const TopMenu = ({selectedMenuChoice, onMenuChange}) => {
     return (
         <div className="helpmenupanel">
             <MenuButton
                 key="WELCOME"
                 text="Welcome"
+                selected={selectedMenuChoice == WELCOME}
                 onMenuButtonClick={() => onMenuChange(WELCOME)}/>
             <MenuButton
                 key="QUICK_REFERENCE"
                 text="Quick Reference"
+                selected={selectedMenuChoice == QUICK_REFERENCE}
                 onMenuButtonClick={() => onMenuChange(QUICK_REFERENCE)}/>
             <MenuButton
                 key="FULL_API_REFERENCE"
                 text="Full API Reference"
+                selected={selectedMenuChoice == FULL_API_REFERENCE}
                 onMenuButtonClick={() => onMenuChange(FULL_API_REFERENCE)}/>
             <MenuButton
                 key="START_TUTORIAL"

--- a/server/src/css/help.css
+++ b/server/src/css/help.css
@@ -209,3 +209,53 @@ position: fixed;
 	color: white;
 	cursor: pointer;
 }
+
+/* Selected tab in the help top menu. Both .helpmenuitem and .helpbutton are on
+   these elements and .helpbutton wins on background, so this has to come after
+   it in the file to take effect. Selected reads as "continuous with the panel
+   below it": panel-colored fill instead of the dark olive. */
+.helpmenuitemselected {
+	background-color: #fcf7bb;
+	color: #736b0d;
+	font-weight: bold;
+}
+
+/* Section jump-links at the top of the full API reference. */
+.infopanel .apinav {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 5px;
+	margin-bottom: 18px;
+	padding-bottom: 12px;
+	border-bottom: 1px solid #736b0d;
+}
+
+.infopanel .apinavitem {
+	display: inline-block;
+	font-size: 1.1em;
+	padding: 2px 5px 3px 5px;
+	background-color: #eef1dc;
+	border: 1px solid #736b0d;
+	cursor: pointer;
+}
+
+.infopanel .apinavitem:hover {
+	background-color: #736b0d;
+	color: #fcf7bb;
+}
+
+.infopanel .apibacktotop {
+	display: inline-block;
+	font-size: 0.95em;
+	padding: 1px 5px 2px 5px;
+	margin-bottom: 4px;
+	border: 1px solid #736b0d;
+	background-color: #fcf7bb;
+	cursor: pointer;
+}
+
+.infopanel .apibacktotop:hover {
+	background-color: #736b0d;
+	color: #fcf7bb;
+}

--- a/server/src/css/theme-dark.css
+++ b/server/src/css/theme-dark.css
@@ -70,3 +70,32 @@ body {
   background-color:  #252623;
 }
 
+
+.helpmenuitemselected {
+  background-color: #3a392b;
+  color: #d8d6b0;
+}
+
+.infopanel .apinav {
+  border-bottom-color: #6b6a4f;
+}
+
+.infopanel .apinavitem {
+  background-color: #41413c;
+  border-color: #6b6a4f;
+}
+
+.infopanel .apinavitem:hover {
+  background-color: #6b6a4f;
+  color: #fcf7bb;
+}
+
+.infopanel .apibacktotop {
+  background-color: #3a392b;
+  border-color: #6b6a4f;
+}
+
+.infopanel .apibacktotop:hover {
+  background-color: #6b6a4f;
+  color: #fcf7bb;
+}


### PR DESCRIPTION
The full API reference is long and had no way to move around it. There's now
a section index at the top that jumps rather than scrolls, and a back-to-top
link at the start of each section.

The help tabs gave no indication of which one you were looking at.

The quick reference gains a section on working with sound nexes, since those
have UI commands that aren't discoverable anywhere else, and collapse and
unroll, which were undocumented.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 10 of 15. Base: `pr-builtin-docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
