### PR TITLE
[7/20] ctrl-s inside eval-and-save should use it, not wrap it in another save

### DIFF
--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -1694,11 +1694,21 @@ class Manipulator {
 	}
 
 	// used in keydispatcher.js
+	// Commands that already save the thing they contain. ctrl-s inside one of
+	// these should use it rather than wrapping it in a second save.
+	isSaveCommand(p) {
+		if (!Utils.isCommand(p)) {
+			return false;
+		}
+		let t = p.nex.getCommandText();
+		return t == 'save' || t == 'eval-and-save';
+	}
+
 	doSave() {
 		let p = this.selected();
 
 		while(!Utils.isRoot(p)) {
-			if (Utils.isCommand(p) && p.nex.getCommandText() == 'save') {
+			if (this.isSaveCommand(p)) {
 				return p;
 			}
 			p = p.getParent();


### PR DESCRIPTION
The shortcut checked for a command literally named 'save', so pressing ctrl-s
while inside an eval-and-save wrapped it in a second save command rather than
recognising the one already there.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 12 of 15. Base: `pr-keydispatcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
