### PR TITLE
[8/20] Let wavetables opt out of serializing their samples, and tidy list-audio

### DIFF
--- a/server/packages/audio-functions
+++ b/server/packages/audio-functions
@@ -1,0 +1,1 @@
+v2:?{2||creating package}

--- a/server/src/builtins/filebuiltins.js
+++ b/server/src/builtins/filebuiltins.js
@@ -56,6 +56,19 @@ import {
 } from '../servercommunication.js'
 
 
+// A listing entry is audio if it's a string ending in .wav. Anything else in a
+// bank folder (info.txt, a nested directory) is not something load-sample can use.
+function isWavFile(nex) {
+	if (!nex || Utils.isNexContainer(nex)) {
+		return false;
+	}
+	if (!nex.getFullTypedValue) {
+		return false;
+	}
+	let v = nex.getFullTypedValue();
+	return typeof v == 'string' && v.toLowerCase().endsWith('.wav');
+}
+
 function createFileBuiltins() {
 
 	Builtin.createBuiltin(
@@ -90,7 +103,32 @@ function createFileBuiltins() {
 				'list-audio', 
 				function(callback, deferredValue) {
 					listAudio(function(files) {
-						// turn files into an org or whatever
+						// The directory listing is generic: subdirectories come back
+						// as tagged orgs, loose files as plain strings. For audio we
+						// only care about the banks, and a stray file (the README,
+						// say) breaks callers that expect every item to be taggable.
+						// So drop non-containers, and flip each bank horizontal --
+						// one very tall column per bank reads badly.
+						if (files.numChildren) {
+							for (let i = files.numChildren() - 1; i >= 0; i--) {
+								let dir = files.getChildAt(i);
+								if (!Utils.isNexContainer(dir)) {
+									files.removeChildAt(i);
+									continue;
+								}
+								// Each bank also holds an info.txt naming the machine
+								// the samples came from. Keep only the audio, so a
+								// caller can map load-sample over a bank directly.
+								for (let j = dir.numChildren() - 1; j >= 0; j--) {
+									if (!isWavFile(dir.getChildAt(j))) {
+										dir.removeChildAt(j);
+									}
+								}
+								if (dir.setHorizontal) {
+									dir.setHorizontal();
+								}
+							}
+						}
 						callback(files);
 					})
 				}

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -51,6 +51,28 @@ import { getAudioBufferFromData, startRecordingAudio, stopRecordingAudio } from 
 /**
  * Nex that represents a wavetable value.
  */
+// When false, wavetables serialize as silence instead of their real samples.
+// Used by autosave; see serializePrivateData below.
+let serializeAudioData = true;
+
+function setSerializeAudioData(v) {
+	serializeAudioData = v;
+}
+
+// A wavetable of DEFAULT_SIZE silent samples, encoded once. Emitting this rather
+// than an empty string means a restored wavetable is structurally identical to a
+// freshly inserted one, instead of a zero-length oddity the renderer has never
+// seen.
+const DEFAULT_SIZE = 256;
+const SILENT_WAVETABLE_DATA = (function() {
+	let bytes = new Uint8Array(new Float32Array(DEFAULT_SIZE).buffer);
+	let s = '';
+	for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+	return typeof window !== 'undefined' && window.btoa
+			? window.btoa(s)
+			: Buffer.from(s, 'binary').toString('base64');
+})();
+
 class Wavetable extends Nex {
 	constructor(initSize) {
 		super();
@@ -412,6 +434,13 @@ class Wavetable extends Nex {
 	}
 
 	serializePrivateData() {
+		// Autosave turns this off: sample data is far too large for localStorage
+		// (roughly 250KB of base64 per second of audio), so wavetables are written
+		// out silent and come back as empty ones. Saving to the server is
+		// unaffected and still writes the real audio.
+		if (!serializeAudioData) {
+			return SILENT_WAVETABLE_DATA;
+		}
 		let s = '';
 		let bytes = new Uint8Array(this.data.buffer);
 		let len = bytes.byteLength;
@@ -1101,4 +1130,4 @@ stats: ${heap.stats()}`)
 }
 
 
-export { Wavetable, WavetableEditor, constructWavetable }
+export { Wavetable, WavetableEditor, constructWavetable, setSerializeAudioData }


### PR DESCRIPTION
setSerializeAudioData lets a wavetable be written without its sample data.
Serialized audio is a base64 blob of every sample, so a document with a few
sounds in it becomes megabytes -- fine for a file on disk, not fine for
anything with a size limit.

list-audio was returning info.txt alongside the actual sounds, so filtering
its results by name picked up a text file. Directories now come back as
horizontal lists, which is worth special-casing here because this is a builtin
and its output is always the same shape.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 13 of 15. Base: `pr-save-shortcut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
