### PR TITLE
[11/21] Store wavetable samples in IndexedDB so audio survives a reload

### DIFF
--- a/server/src/audiostore.js
+++ b/server/src/audiostore.js
@@ -1,0 +1,241 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+Sample storage for autosave, kept in IndexedDB rather than localStorage.
+
+localStorage holds strings, so samples have to be base64'd -- a third larger
+than the bytes they encode -- against a budget of about 5MB total. One second
+of audio is roughly 250KB encoded, so a handful of sounds fills it. That is
+why autosave has been writing wavetables out silent. IndexedDB stores a
+Float32Array directly with no encoding step, and its quota is a fraction of
+free disk rather than a fixed few megabytes.
+
+The asynchrony is deliberately not visible to the rest of the app. Everything
+is read into memory once, during startup, before the document is built; from
+then on get() is an ordinary synchronous lookup and nothing in the evaluator,
+the renderer or the wavetable code has to know where the samples came from.
+Writes go out in the background and nobody waits for them.
+
+Samples are keyed by a hash of their contents, which means the identity
+question -- "is this the same audio as before?" -- has an answer that doesn't
+depend on tracking which wavetable owns what. Two wavetables holding identical
+audio share one record, and a wavetable whose samples were edited writes a new
+one. Records nothing refers to any more are pruned after a save.
+*/
+
+import { systemState } from './systemstate.js'
+
+const DB_NAME = 'vodka-audio';
+const DB_VERSION = 1;
+const STORE = 'samples';
+
+// Records are namespaced by session id for the same reason the localStorage key
+// is: two sessions open in two tabs shouldn't see each other's audio.
+function scopedKey(hash) {
+	let id = systemState.getSessionId();
+	return (id ? id : 'nosession') + '/' + hash;
+}
+
+// Everything read at startup. get() serves from here, so callers never see a
+// promise.
+let loaded = new Map();
+
+// Set when IndexedDB is unavailable or refuses us -- a private window, blocked
+// site data, an old browser. Autosave then behaves as it did before: documents
+// round-trip, audio doesn't.
+let unavailable = false;
+
+let dbPromise = null;
+
+function openDb() {
+	if (dbPromise) {
+		return dbPromise;
+	}
+	dbPromise = new Promise(function(resolve) {
+		let req;
+		try {
+			req = window.indexedDB.open(DB_NAME, DB_VERSION);
+		} catch (e) {
+			unavailable = true;
+			resolve(null);
+			return;
+		}
+		req.onupgradeneeded = function() {
+			let db = req.result;
+			if (!db.objectStoreNames.contains(STORE)) {
+				db.createObjectStore(STORE);
+			}
+		};
+		req.onsuccess = function() { resolve(req.result); };
+		req.onerror = function() { unavailable = true; resolve(null); };
+		req.onblocked = function() { unavailable = true; resolve(null); };
+	});
+	return dbPromise;
+}
+
+/*
+Reads every sample record for this session into memory. Call once, and await it
+before building the document -- that await is the only place the asynchrony
+exists, and it happens during startup where there is nothing to block.
+*/
+function loadAll() {
+	return openDb().then(function(db) {
+		if (!db) return;
+		return new Promise(function(resolve) {
+			let tx;
+			try {
+				tx = db.transaction(STORE, 'readonly');
+			} catch (e) {
+				unavailable = true;
+				resolve();
+				return;
+			}
+			let store = tx.objectStore(STORE);
+			let req = store.openCursor();
+			let prefix = scopedKey('');
+			req.onsuccess = function() {
+				let cursor = req.result;
+				if (!cursor) {
+					resolve();
+					return;
+				}
+				let k = '' + cursor.key;
+				if (k.indexOf(prefix) == 0) {
+					loaded.set(k.substring(prefix.length), cursor.value);
+				}
+				cursor.continue();
+			};
+			req.onerror = function() { resolve(); };
+		});
+	}).catch(function() {
+		unavailable = true;
+	});
+}
+
+// Synchronous by design -- see the note at the top of the file.
+function get(hash) {
+	let v = loaded.get(hash);
+	if (!v) return null;
+	// Stored as a plain ArrayBuffer; hand back the view the caller expects.
+	return new Float32Array(v);
+}
+
+function has(hash) {
+	return loaded.has(hash);
+}
+
+/*
+Records the samples under their hash and writes them out in the background.
+Returns immediately; the in-memory copy is updated first, so a get() right
+after a put() works whether or not the write has landed.
+*/
+function put(hash, float32array) {
+	if (unavailable) return;
+	if (loaded.has(hash)) {
+		// Same contents, already stored. Nothing to write.
+		return;
+	}
+	let buffer = float32array.buffer.slice(
+			float32array.byteOffset,
+			float32array.byteOffset + float32array.byteLength);
+	loaded.set(hash, buffer);
+	openDb().then(function(db) {
+		if (!db) return;
+		try {
+			let tx = db.transaction(STORE, 'readwrite');
+			tx.objectStore(STORE).put(buffer, scopedKey(hash));
+		} catch (e) {
+			unavailable = true;
+		}
+	});
+}
+
+/*
+Drops records no longer referenced by the saved document. Without this, editing
+a wavetable would leave its previous contents behind forever, and a long
+session would accumulate every intermediate state of every sound.
+
+Takes the set of hashes the document still mentions. Background, like put().
+*/
+function pruneToKeys(keysInUse) {
+	if (unavailable) return;
+	let dead = [];
+	loaded.forEach(function(value, hash) {
+		if (!keysInUse.has(hash)) {
+			dead.push(hash);
+		}
+	});
+	if (dead.length == 0) return;
+	for (let i = 0; i < dead.length; i++) {
+		loaded.delete(dead[i]);
+	}
+	openDb().then(function(db) {
+		if (!db) return;
+		try {
+			let tx = db.transaction(STORE, 'readwrite');
+			let store = tx.objectStore(STORE);
+			for (let i = 0; i < dead.length; i++) {
+				store.delete(scopedKey(dead[i]));
+			}
+		} catch (e) {
+			unavailable = true;
+		}
+	});
+}
+
+/*
+FNV-1a over the sample bytes. Not cryptographic -- it decides "have I already
+stored exactly these samples", and a collision would mean one wavetable coming
+back as another, so the length is mixed in and the hash is taken over the raw
+bytes rather than the float values.
+
+Cost is a pass over the buffer, which at a 800ms save debounce is not something
+a person can notice.
+*/
+function hashSamples(float32array) {
+	let bytes = new Uint8Array(
+			float32array.buffer,
+			float32array.byteOffset,
+			float32array.byteLength);
+	let h1 = 0x811c9dc5;
+	let h2 = 0x01000193;
+	for (let i = 0; i < bytes.length; i++) {
+		h1 ^= bytes[i];
+		h1 = Math.imul(h1, 0x01000193);
+		// second accumulator over the same data with a different seed, so the
+		// key is 64 bits rather than 32
+		h2 = Math.imul(h2 ^ bytes[i], 0x85ebca6b);
+	}
+	let a = (h1 >>> 0).toString(16);
+	let b = (h2 >>> 0).toString(16);
+	return bytes.length.toString(16) + '-' + a + b;
+}
+
+function isUnavailable() {
+	return unavailable;
+}
+
+export {
+	loadAll,
+	get,
+	has,
+	put,
+	pruneToKeys,
+	hashSamples,
+	isUnavailable
+}

--- a/server/src/autosave.js
+++ b/server/src/autosave.js
@@ -27,9 +27,11 @@ Two things worth knowing about what gets stored:
     case where the root holds more than one thing, which doSave() clearly
     anticipates.
 
-  - Audio is not stored. A second of samples is about 250KB of base64, and the
-    whole localStorage budget is around 5MB, so wavetables are written out
-    silent and come back empty. Everything else round-trips.
+  - Audio doesn't go in localStorage. A second of samples is about 250KB of
+    base64 against a budget of around 5MB, so a wavetable serializes as a
+    reference and its samples go to IndexedDB instead -- see audiostore.js.
+    Where IndexedDB isn't available the old behaviour stands: wavetables come
+    back silent and everything else round-trips.
 
 Storage is keyed by session id, so two tabs on different sessions don't collide.
 Two tabs on the *same* session share one slot and the last writer wins.
@@ -38,6 +40,7 @@ Two tabs on the *same* session share one slot and the last writer wins.
 import { systemState } from './systemstate.js'
 import { parse } from './nexparser2.js'
 import { setSerializeAudioData } from './nex/wavetable.js'
+import * as audioStore from './audiostore.js'
 
 const KEY_PREFIX = 'vodka.autosave.';
 const FORMAT_VERSION = 1;
@@ -104,6 +107,26 @@ function saveNow(rootNode) {
 		sessionId: systemState.getSessionId() || null,
 		docs: docs
 	}));
+	// Samples the document no longer mentions are dead. Editing a wavetable
+	// gives its new contents a new hash, so without this every intermediate
+	// state of every sound would be kept forever. Reading the references back
+	// out of what we just wrote is the cheapest way to know exactly what
+	// survived, and can't drift from it.
+	audioStore.pruneToKeys(collectAudioRefs(docs));
+}
+
+const AUDIO_REF_RE = /idb:([0-9a-f]+-[0-9a-f]+)/g;
+
+function collectAudioRefs(docs) {
+	let keys = new Set();
+	for (let i = 0; i < docs.length; i++) {
+		let m;
+		AUDIO_REF_RE.lastIndex = 0;
+		while ((m = AUDIO_REF_RE.exec(docs[i])) !== null) {
+			keys.add(m[1]);
+		}
+	}
+	return keys;
 }
 
 /**
@@ -165,6 +188,28 @@ function enableAutosave() {
 	restored = true;
 }
 
+/**
+ * Writes a pending save immediately instead of waiting out the debounce.
+ *
+ * Without this, anything done in the last SAVE_DELAY_MS before a reload is
+ * simply gone -- which at 800ms is most of a second of work, and is exactly
+ * the window a person is in when they change something and reload to see what
+ * happened. beforeunload gives us a synchronous moment to spend, and
+ * localStorage is synchronous, so the pending write lands.
+ *
+ * Sample data is already in IndexedDB by this point: put() writes as soon as
+ * the samples are serialized rather than waiting for the debounce, so what's
+ * pending here is only the document itself.
+ */
+function installUnloadFlush(rootNode) {
+	window.addEventListener('beforeunload', function() {
+		if (!pendingSave) return;
+		clearTimeout(pendingSave);
+		pendingSave = null;
+		saveNow(rootNode);
+	});
+}
+
 function clearAutosave() {
 	try {
 		window.localStorage.removeItem(storageKey());
@@ -173,4 +218,4 @@ function clearAutosave() {
 	}
 }
 
-export { scheduleAutosave, restoreAutosave, enableAutosave, clearAutosave, saveNow }
+export { scheduleAutosave, restoreAutosave, enableAutosave, clearAutosave, saveNow, installUnloadFlush }

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -37,6 +37,7 @@ import { showManipulator } from '../wtmanip.js'
 import { Editor } from '../editors.js'
 import { doTutorial } from '../help.js'
 import { getAudioBufferFromData, startRecordingAudio, stopRecordingAudio } from '../webaudio.js'
+import * as audioStore from '../audiostore.js'
 
 
 // zoom essentially means a number of pixels equals a number of samples
@@ -54,6 +55,10 @@ import { getAudioBufferFromData, startRecordingAudio, stopRecordingAudio } from 
 // When false, wavetables serialize as silence instead of their real samples.
 // Used by autosave; see serializePrivateData below.
 let serializeAudioData = true;
+
+// Marks a serialized wavetable whose samples live in IndexedDB rather than in
+// the document. Chosen so it can't collide with base64, which has no colon.
+const AUDIO_REF_PREFIX = 'idb:';
 
 function setSerializeAudioData(v) {
 	serializeAudioData = v;
@@ -415,6 +420,26 @@ class Wavetable extends Nex {
 	}
 
 	deserializePrivateData(data) {
+		// A reference rather than the samples themselves, written by autosave.
+		// The lookup is synchronous because every record was read into memory
+		// during startup, before any document was built -- see audiostore.js.
+		if (data.indexOf(AUDIO_REF_PREFIX) == 0) {
+			let hash = data.substring(AUDIO_REF_PREFIX.length);
+			let samples = audioStore.get(hash);
+			if (!samples || samples.length == 0) {
+				// Referenced audio isn't there: storage was cleared, or the
+				// quota evicted it. Come back as silence rather than failing to
+				// restore the document at all. Length matters as well as
+				// presence -- a zero-length buffer is truthy, and a wavetable
+				// with no samples can't build an AudioBuffer, so it would throw
+				// on the way out of here.
+				samples = new Float32Array(DEFAULT_SIZE);
+			}
+			this.data = samples;
+			heap.requestMem(this.data.length * heap.incrementalSizeWavetable());
+			this.init();
+			return;
+		}
 		// I don't know when this gets called?
 		let s = window.atob(data);
 		let len = s.length;
@@ -434,12 +459,20 @@ class Wavetable extends Nex {
 	}
 
 	serializePrivateData() {
-		// Autosave turns this off: sample data is far too large for localStorage
-		// (roughly 250KB of base64 per second of audio), so wavetables are written
-		// out silent and come back as empty ones. Saving to the server is
-		// unaffected and still writes the real audio.
+		// Autosave turns inline serialization off: sample data is far too large
+		// for localStorage (roughly 250KB of base64 per second of audio). The
+		// samples go to IndexedDB instead and what lands in the document is a
+		// reference to them. Saving to the server is unaffected and still writes
+		// the real audio inline.
 		if (!serializeAudioData) {
-			return SILENT_WAVETABLE_DATA;
+			if (audioStore.isUnavailable()) {
+				// No IndexedDB -- a private window, blocked site data. Fall back
+				// to the old behaviour: structure survives, audio doesn't.
+				return SILENT_WAVETABLE_DATA;
+			}
+			let hash = audioStore.hashSamples(this.data);
+			audioStore.put(hash, this.data);
+			return AUDIO_REF_PREFIX + hash;
 		}
 		let s = '';
 		let bytes = new Uint8Array(this.data.buffer);

--- a/server/src/parserfunctions.js
+++ b/server/src/parserfunctions.js
@@ -182,7 +182,13 @@ function makeInstanceAtom(instname, privatedata, taglist, nonmutable) {
 			t = constructNil();
 			break;
 		case 'wavetable':
-			t = constructWavetable(concatParserString(privatedata));
+			// No size argument. constructWavetable's parameter is a sample
+			// count, and passing the serialized private data here meant
+			// new Float32Array("<base64 or reference>"), which is NaN samples,
+			// which is a zero-length buffer, which throws out of createBuffer
+			// before setPrivateData below ever gets to install the real data.
+			// Any saved wavetable failed to parse because of it.
+			t = constructWavetable();
 			break;
 		case 'surface':
 			t = constructSurface(concatParserString(privatedata));

--- a/server/src/vodka.js
+++ b/server/src/vodka.js
@@ -70,7 +70,8 @@ import { maybeKillSound } from './webaudio.js'
 // import { setupMobile, doMobileKeyDown } from './mobile.js'
 
 import { getFeatureVector } from './featurevector.js'
-import { restoreAutosave, enableAutosave } from './autosave.js'
+import { restoreAutosave, enableAutosave, installUnloadFlush } from './autosave.js'
+import * as audioStore from './audiostore.js'
 
 
 // EXPERIMENTS
@@ -260,12 +261,20 @@ function installTestHooks() {
 
 // app main entry point
 
-function setup() {
+// Async only because of audioStore.loadAll(), which pulls the saved samples
+// into memory before any document is built. That await is the whole of the
+// asynchrony -- after it, wavetables get their samples from a synchronous
+// lookup and nothing downstream knows storage was involved. Nothing waits on
+// setup()'s return; vodkastart.js calls it at module top level.
+async function setup() {
 	setAppFlags();
 	suppressAnimationsIfRequested();
 	installTestHooks();
 	// do session id before doing help
 	setOrCreateSessionId();
+
+	// after the session id, because records are namespaced by it
+	await audioStore.loadAll();
 
 	eventQueue.initialize();
 
@@ -345,7 +354,12 @@ function setup() {
 	// wherever a restore was attempted, so this only matters for the branches
 	// that loaded a document explicitly.
 	enableAutosave();
+	installUnloadFlush(root);
 	eventQueueDispatcher.enqueueRenderOnlyDirty()
+	// setup() is async now, so "the page has loaded" no longer means "the app
+	// is ready". Anything driving the app from outside -- the test harness --
+	// has to wait for this rather than for the network to go idle.
+	window.__vodkaReady = true;
 }
 
 

--- a/testing/testharness.js
+++ b/testing/testharness.js
@@ -278,6 +278,8 @@ function runTestImpl(testinput, method, legacy, flags) {
 				window.legacyEnterBehaviorForTests = true;
 			})
 		}
+		// setup() is async, so network idle doesn't mean the app is ready
+		await page.waitForFunction(function() { return !!window.__vodkaReady; });
 		await drain(page);
 		if (method == 'direct' || method == 'direct-legacy') {
 //			await page.evaluate(function() {


### PR DESCRIPTION
Autosave has been writing wavetables out silent, because samples in
localStorage mean base64 -- a third larger than the bytes they encode --
against a budget of about 5MB. One second of audio is roughly 250KB encoded.

Samples now go to IndexedDB, which stores a Float32Array directly with no
encoding step and has a quota measured against free disk. What lands in the
document is a reference rather than the audio.

The asynchrony is not visible anywhere else. Everything is read into memory
once during startup, before any document is built, so the lookup on the way
back is an ordinary synchronous call and nothing in the evaluator, the
renderer or wavetable.js has to know where the samples came from. Writes go
out in the background and nobody waits. No deferreds are involved.

setup() becomes async as a result, which means "the page loaded" no longer
means "the app is ready" -- it sets window.__vodkaReady when it is, and the
test harness waits for that instead of for the network to go idle.

Samples are keyed by a hash of their contents, so "is this the same audio as
before" has an answer that doesn't depend on tracking which wavetable owns
what. Two wavetables holding identical audio share one record; an edited
wavetable writes a new one and the old record is pruned on the next save,
which stops a long session accumulating every intermediate state of every
sound.

Two bugs found on the way, both of which had to be fixed for any of this to
work:

- parserfunctions.js passed a wavetable's serialized private data to
  constructWavetable as its *sample count*. That's new Float32Array of a
  string, which is NaN samples, which is a zero-length buffer, which throws
  out of createBuffer before setPrivateData gets to install the real data.
  Every saved wavetable failed to parse, silently -- restoreAutosave catches
  per item, so the whole top-level item vanished. This predates the IndexedDB
  work and broke the base64 path identically, which is why autosave had never
  restored a wavetable.

- Anything done in the last 800ms before a reload was lost, which is exactly
  the window you're in when you change something and reload to look at it.
  Pending saves are now flushed on beforeunload.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR 16 of 16. Base: `pr-autosave`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT
