### PR TITLE
[2/17] Guard against editing something that has no editor

### DIFF
--- a/server/src/actions.js
+++ b/server/src/actions.js
@@ -147,7 +147,9 @@ class EditorContentChangeAction extends Action {
 	doAction() {
 		let selectedNode = systemState.getGlobalSelectedNode();
 		let fakeEditor = selectedNode.getEditorForType(selectedNode.nex);
-		this.savedEditorData = fakeEditor.getStateForUndo();
+		if (fakeEditor) {
+			this.savedEditorData = fakeEditor.getStateForUndo();
+		}
 		KeyResponseFunctions[this.actionName](selectedNode);
 	}
 
@@ -157,7 +159,9 @@ class EditorContentChangeAction extends Action {
 		// then you try to undo, and the correct thing isn't selected.
 		let selectedNode = systemState.getGlobalSelectedNode();
 		let fakeEditor = selectedNode.getEditorForType(selectedNode.nex);
-		fakeEditor.setStateForUndo(this.savedEditorData);
+		if (fakeEditor) {
+			fakeEditor.setStateForUndo(this.savedEditorData);
+		}
 	}
 }
 


### PR DESCRIPTION
EditorContentChangeAction dereferenced getEditorForType's result without
checking it, unlike every other caller in the file. Backspace reaches it
through start-main-editor, so backspacing on a settled deferred value threw --
by hand, not just in tests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT

Stacked PR. Base: `pr-deferred-state`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT