### PR TITLE
[12/21] Put the session id in the URL, and mark generated sessions with a prefix

### DIFF
--- a/server/src/components/welcome_panel.jsx
+++ b/server/src/components/welcome_panel.jsx
@@ -23,7 +23,7 @@ const WelcomePanel = () => {
         <p className="infoline">Your session ID is <span id="sessionid">{sessionId}</span>.</p>
         <p className="infoline">All data you save via the (_save_) and (_save-file_) builtins is sandboxed to this session.</p>
         <p className="infoline">You can access this session again with <a id="sessionlink" href={buildURL({ "sessionId": sessionId })}>this link</a>.</p>
-        <p className="infoline">You can leave this session and start a whole new session with <a id="newsessionlink" href={buildURL({ "sessionId": null, "new": 1 })}>this link</a>.</p>
+        <p className="infoline">You can leave this session and start a whole new session with <a id="newsessionlink" href={buildURL({ "sessionId": null, "new": 1 })}>this link</a>, or by deleting the sessionId from the address bar.</p>
         <p className="infoline">You can create an exact copy of this session (with all the same saved files) with <a id="copysessionlink" href={buildURL({ "sessionId": null, "copy": 1 })}>this link</a>.</p>
         <p className="infoline">You can create a read-only copy of this session (e.g. for sharing on social media) with <a id="sharesessionlink" href={buildURL({ "sessionId": null, "copy": 1, "type": "readonly" })}>this link</a>.</p>
         <p className="infoline">To have a file load and be evaluated in normal mode at startup when a session link is visited, name the file "start-doc".</p>

--- a/server/tools/createnamedsession.js
+++ b/server/tools/createnamedsession.js
@@ -1,0 +1,82 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+Creates a named session. Used to be possible over HTTP with ?new&sessionId=,
+which let anyone claim any name.
+
+  node tools/createnamedsession.js <name>
+
+Run from the server directory.
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+// kept in step with webserver.js
+const GENERATED_SESSION_PREFIX = 'vs-';
+
+const RESERVED = ['packages', 'samples'];
+
+function fail(message) {
+	console.error('createnamedsession: ' + message);
+	process.exit(1);
+}
+
+function main() {
+	let name = process.argv[2];
+
+	if (!name) {
+		console.error('usage: node tools/createnamedsession.js <name>');
+		process.exit(1);
+	}
+
+	if (RESERVED.indexOf(name) >= 0) {
+		fail(`"${name}" is reserved.`);
+	}
+
+	if (name.indexOf(GENERATED_SESSION_PREFIX) === 0) {
+		fail(`"${GENERATED_SESSION_PREFIX}" is reserved for sessions the server generates.`
+				+ ` A named session starting with it would be looked for in the wrong directory.`);
+	}
+
+	if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+		fail(`"${name}" is not a valid name -- letters, digits, underscores and hyphens only.`);
+	}
+
+	// relative, same as the server resolves them
+	let dir = path.join('./namedsessions', name);
+
+	if (!fs.existsSync('./namedsessions')) {
+		fail('no namedsessions directory here -- run this from the server directory.');
+	}
+
+	if (fs.existsSync(dir)) {
+		fail(`session "${name}" already exists at ${dir}`);
+	}
+
+	try {
+		fs.mkdirSync(dir);
+	} catch (e) {
+		fail(`could not create ${dir}: ${e.message}`);
+	}
+
+	console.log(`created named session "${name}" at ${dir}`);
+	console.log(`open it at /?sessionId=${name}`);
+}
+
+main();

--- a/server/webserver.js
+++ b/server/webserver.js
@@ -34,6 +34,14 @@ const webenv_vars = {}
 
 const ERROR = "Rather than a beep<br>Or a rude error message,<br>These words: \"File not found.\"";
  
+// generated sessions live in sessions/, named ones in namedsessions/
+const GENERATED_SESSION_PREFIX = 'vs-';
+
+function isGeneratedSessionId(sessionId) {
+	return typeof sessionId === 'string'
+			&& sessionId.indexOf(GENERATED_SESSION_PREFIX) === 0;
+}
+
 let api_reqs = 1;
 let total_reqs = 1;
 
@@ -73,28 +81,11 @@ async function processRequest(req, resp) {
 				});
 		})
 	} else if (query.new) {
-		let sessionId = query.sessionId;
-		if (sessionId) {
-			let exists = await checkIfSessionExists(query.sessionId);
-			if (exists) {
-				sendResponse(resp, 401, 'text/html', 'cannot create, session exists already.');
-				return;
-			}
-			if (!isValidSessionNameForUserCreate(query.sessionId)) {
-				sendResponse(resp, 401, 'text/html', 'invalid session name');
-				return;
-			}
-			let success = await createSession(sessionId, resp);
-			if (!success) {
-				sendResponse(resp, 401, 'text/html', 'could not create session');
-				return;
-			}
-		} else {
-			sessionId = await createNewUUIDSession(resp);
-			if (!sessionId) {
-				sendResponse(resp, 401, 'text/html', 'could not create session');
-				return;
-			}
+		// named sessions are made with tools/createnamedsession.js
+		let sessionId = await createNewUUIDSession(resp);
+		if (!sessionId) {
+			sendResponse(resp, 401, 'text/html', 'could not create session');
+			return;
 		}
 		sendRedirect(resp, `http://${webenv_vars.redirectHostname}/?sessionId=${sessionId}`);
 		return;
@@ -151,6 +142,11 @@ async function processRequest(req, resp) {
 	} else if (sessionIdFromCookie) {
 		let sessionId = sessionIdFromCookie;
 		let exists = await checkIfSessionExists(sessionId);
+		if (exists) {
+			// in the URL so it's bookmarkable, and so removing it asks for a new one
+			sendRedirect(resp, `http://${webenv_vars.redirectHostname}/?sessionId=${sessionId}`);
+			return;
+		}
 		if (!exists) {
 			// if the user sends an unknown session ID in the cookie, it could be that
 			// their session was deleted. Since users shouldn't be manually inserting
@@ -171,13 +167,13 @@ async function processRequest(req, resp) {
 			sendResponse(resp, 401, 'text/html', 'could not create session');
 			return;
 		}
-		serviceRequestForRegularFile(newSessionId, path, resp);
+		sendRedirect(resp, `http://${webenv_vars.redirectHostname}/?sessionId=${newSessionId}`);
 		return;
 	}
 };
 
 async function createNewUUIDSession(resp) {
-	let newSessionId = uuidv4();
+	let newSessionId = GENERATED_SESSION_PREFIX + uuidv4();
 	let success = await createSession(newSessionId, resp);
 	return success ? newSessionId : null;
 }
@@ -185,7 +181,8 @@ async function createNewUUIDSession(resp) {
 function isValidSessionNameForUserCreate(sessionName) {
 	if (sessionName == 'packages') return false;
 	if (sessionName == 'samples') return false;
-	let isIdentifier = /^[a-zA-Z0-9_]+$/.test(sessionName);
+	if (isGeneratedSessionId(sessionName)) return false;
+	let isIdentifier = /^[a-zA-Z0-9_-]+$/.test(sessionName);
 	return isIdentifier;
 }
 
@@ -422,19 +419,10 @@ function getSessionDirectory(sessionId, localAccessOnly) {
 	let r = '';
 	if (sessionId == 'packages' && (!localAccessOnly || webenv_vars.isLocal)) {
 		r = './packages/'
-	} else {
-
-		let hasDash = /-/.test(sessionId);
-
-		// we don't let users create sessions with dashes in them.
-		// only UUID sessions have dashes.
-		// that way we can keep them in separate directories.
-
+	} else if (isGeneratedSessionId(sessionId)) {
 		r = `./sessions/${sessionId}/`;
-		if (!hasDash) {
-			r = `./namedsessions/${sessionId}/`;
-		}
-
+	} else {
+		r = `./namedsessions/${sessionId}/`;
 	}
 	return r;
 

--- a/testing/runtests.sh
+++ b/testing/runtests.sh
@@ -184,7 +184,17 @@ is_vk() {
 	find ./alltests/$FILE.vk > /dev/null 2> /dev/null
 }
 
+# one session for all tests, emptied first so runs cannot affect each other
+TEST_SESSION_ID="vodka-tests"
+TEST_SESSION_DIR="../server/namedsessions/${TEST_SESSION_ID}"
+
+prepare_test_session() {
+	rm -rf "${TEST_SESSION_DIR}"
+	mkdir -p "${TEST_SESSION_DIR}"
+}
+
 run() {
+	prepare_test_session
 	echo "Vodka test runner. Options:"
 	echo "  --show      launches visible chrome instance so you can watch the test"
 	echo "  --testdir   use a different directory to look for tests"

--- a/testing/testharness.js
+++ b/testing/testharness.js
@@ -52,6 +52,9 @@ var paused = false; // start paused erm...
 // only elapses when a test is already broken
 const IO_TIMEOUT_MS = 10000;
 
+// kept in step with runtests.sh, which clears it before each run
+const TEST_SESSION_ID = 'vodka-tests';
+
 async function drain(page) {
 	return await page.evaluate(function() { return window.__vodkaTest.drain(); });
 }
@@ -222,6 +225,8 @@ function doFlagOverrides(flags) {
 	rflags['TEST_NO_ANIMATIONS'] = true;
 	rflags['TEST_MANUAL_EVENT_QUEUE'] = true;
 	rflags['TEST_VIRTUAL_CLOCK'] = true;
+	// one session for all tests, so the server stops minting one per test
+	rflags['sessionId'] = TEST_SESSION_ID;
 
 	return rflags;
 


### PR DESCRIPTION
Arriving at / left you on a bare URL with the session only in a cookie, so the
address bar said nothing about which session you were in, you couldn't
bookmark or share one, and two tabs silently shared whichever the cookie last
named. Now the id is always in the URL, and removing it is how you ask for a
new session.

Generated sessions are marked 'vs-' rather than being recognised by containing
a hyphen, which is what previously kept hyphens out of named sessions.

Named sessions can no longer be created over HTTP -- ?new&sessionId=<name> let
anyone claim any name. server/tools/createnamedsession.js replaces it.

Tests now share one session, emptied by runtests.sh before each run. The
harness sent no session id, so the server minted a fresh directory per test
and never collected them; they had accumulated into the thousands.

Note for deploy: existing sessions have no prefix, so they will resolve to
namedsessions/ after this. Fine here, since they were all deleted.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT



Stacked PR. Base: `pr-audio-indexeddb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT