### PR TITLE
[16/21] Add a small status nav: unsaved dot and stop-all-sound button

### DIFF
--- a/server/src/autosave.js
+++ b/server/src/autosave.js
@@ -215,6 +215,10 @@ function installUnloadFlush(rootNode) {
 	});
 }
 
+function hasPendingSave() {
+	return !!pendingSave;
+}
+
 function clearAutosave() {
 	try {
 		window.localStorage.removeItem(storageKey());
@@ -223,4 +227,4 @@ function clearAutosave() {
 	}
 }
 
-export { scheduleAutosave, restoreAutosave, enableAutosave, clearAutosave, saveNow, installUnloadFlush }
+export { scheduleAutosave, restoreAutosave, enableAutosave, clearAutosave, saveNow, installUnloadFlush, hasPendingSave }

--- a/server/src/components/app.jsx
+++ b/server/src/components/app.jsx
@@ -5,6 +5,7 @@ import BasicUsagePanel from './basic_usage_panel';
 import ApiReferencePanel from './api_reference_panel';
 import WelcomePanel from './welcome_panel';
 import AccessButton from './access_button';
+import StatusNav from './status_nav';
 import Tutorial from './tutorial';
 
 import { systemState } from '../systemstate.js';
@@ -103,6 +104,7 @@ const App = () => {
 
     return (
         <div>
+            <StatusNav/>
             {
                 (() => {
                     switch(uiState) {

--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'preact/hooks';
+import { isAnySoundPlaying, stopAllSound } from '../webaudio.js';
+import { hasPendingSave } from '../autosave.js';
+
+// Neither playback nor the save debounce announces itself, so poll. Cheap --
+// two boolean reads.
+const POLL_MS = 250;
+
+const StatusNav = () => {
+    const [playing, setPlaying] = useState(false);
+    const [unsaved, setUnsaved] = useState(false);
+
+    useEffect(() => {
+        const id = setInterval(() => {
+            setPlaying(isAnySoundPlaying());
+            setUnsaved(hasPendingSave());
+        }, POLL_MS);
+        return () => clearInterval(id);
+    }, []);
+
+    return (
+        <div className="statusnav">
+            {unsaved && <div className="unsaveddot" title="not saved yet"></div>}
+            {playing &&
+                <div className="statusnavitem stopbutton" title="stop all sound"
+                     onClick={() => { stopAllSound(); setPlaying(false); }}>
+                    <span className="stopbar"></span>
+                    <span className="stopbar"></span>
+                </div>}
+        </div>
+    );
+};
+
+export default StatusNav;

--- a/server/src/css/help.css
+++ b/server/src/css/help.css
@@ -263,3 +263,43 @@ position: fixed;
 .infopanel a {
 	color: var(--help-link);
 }
+
+/* Small persistent nav, sitting to the left of the help button. */
+.statusnav {
+	position: fixed;
+	top: 0px;
+	right: 44px;
+	/* matches the help button's box: 3px margin + 2px border + 2px padding +
+	   9px Courier line, so the row centres against it */
+	margin-top: 3px;
+	height: 17px;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 6px;
+	z-index: 1001;
+}
+
+.statusnavitem {
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.stopbutton {
+	gap: 2px;
+}
+
+.stopbar {
+	width: 3px;
+	height: 9px;
+	background-color: var(--help-accent);
+}
+
+.unsaveddot {
+	width: 4px;
+	height: 4px;
+	border-radius: 50%;
+	background-color: var(--help-accent);
+}

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -275,6 +275,19 @@ function startAuditioningBuffer(buffer, nex) {
 	thingAuditioning = nex;
 }
 
+function isAnySoundPlaying() {
+	if (auditioningPlayer) return true;
+	for (let i = 0; i < channelPlayers.length; i++) {
+		if (channelPlayers[i]) return true;
+	}
+	return false;
+}
+
+function stopAllSound() {
+	maybeKillSound();
+	abortPlayback(-1);
+}
+
 function maybeKillSound() {
 	if (thingAuditioning) {
 		thingAuditioning.stopAuditioningWave();
@@ -300,5 +313,5 @@ async function getFileAsBuffer(filepath) {
 }
 
 
-export { getAudioBufferFromData, loadSample, maybeKillSound, startAuditioningBuffer, getFileAsBuffer, oneshotPlay, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
+export { getAudioBufferFromData, loadSample, maybeKillSound, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, oneshotPlay, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
 


### PR DESCRIPTION
[16/16] — stacked on #317.

Two bits of state that were invisible: whether a save is still pending, and whether anything is playing.

- The dot shows while the autosave debounce is outstanding.
- The stop button only appears while sound is playing, and stops both kinds — auditioning and channel playback are tracked separately, so stopping one left the other running.

Both poll at 250ms rather than being notified. Neither playback nor the save debounce announces itself, and adding notifications to both would have been a much wider change for two boolean reads.

Also drops the theme persistence that was in #317: the query string already survives a refresh, so saving it bought nothing and meant removing `theme=dark` did not go back to light.

Styled for both themes.