### PR TITLE
[17/21] Make the root selection border surround the whole document

### DIFF
--- a/server/src/css/vodka.css
+++ b/server/src/css/vodka.css
@@ -28,24 +28,18 @@ body, html {
 	height:100%;
 }
 
-#hiddenroot {
-	visibility: hidden;
-	width:10000px;
-	/*
-	the hiddenroot is used for width calculations
-	but if the width is not 10000 then the contents get wrapped
-	*/
-}
-
-
 #codepane {
 	height: 100%;
 	width: 100%;
 }
 
 #vodkaroot {
-	height: 100%;
-	width: 100%;	
+	/* never smaller than the viewport, but grows to fit a doc that overflows it,
+	   so the selected-root border surrounds the whole doc and not just the
+	   first screenful */
+	min-height: 100%;
+	min-width: 100%;
+	width: fit-content;
 }
 
 .glyphleft {

--- a/server/src/host.html
+++ b/server/src/host.html
@@ -280,7 +280,6 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	</div>
 	<div id="codepane">
 		<div id="vodkaroot"></div>
-		<div id="hiddenroot"></div>
 	</div>
 
 	<!--

--- a/server/src/rootmanager.js
+++ b/server/src/rootmanager.js
@@ -47,36 +47,60 @@ class RootManager  {
 		if (!args.mode) {
 			args.mode = RENDER_MODE_NORM;
 		}
-		if (!args.id) {
-			args.id = 'vodkaroot';
+		if (!args.domNode) {
+			args.domNode = document.getElementById(args.id ? args.id : 'vodkaroot');
 		}
 		let rootnex = new Root(true /* attached */);
 		let root = new RenderNode(rootnex);
 		root.setRenderMode(args.mode);
 		root.setRenderDepth(0);
 		document.vodkaroot = root; // for debugging in chrome dev tools
-		let rootDomNode = document.getElementById(args.id);
-		root.setDomNode(rootDomNode);
+		root.setDomNode(args.domNode);
 		rootnex.setDirtyForRendering(true);
 		systemState.setRoot(root);
 		return root;	
 	}
 
-	renderInHiddenRoot(nex, rendermode) {
+	// renders the nex into a scratch node, hands it to measureFn to be measured,
+	// then throws the scratch node away and returns whatever measureFn returned.
+	// The measuring has to happen in here because the node can't be measured once
+	// it's been detached.
+	measureInHiddenRoot(nex, rendermode, measureFn) {
 		let wasDirty = nex.getDirtyForRendering();
-		let hiddenRoot = this.createNewRoot({
-			mode: rendermode,
-			id: 'hiddenroot'
-		})
+		let savedRoot = systemState.getRoot();
+		let savedDebugRoot = document.vodkaroot;
 
-		// render pass has to monotonically increase but it can skip, so when this is
-		// called, the main (visible) render pass number will skip numbers.
-		systemState.setGlobalRenderPassNumber(systemState.getGlobalRenderPassNumber() + 1);
-		// has to be synchronous so we can measure
-		hiddenRoot.render();
-		// if it was dirty before, re-dirty it
-		nex.setDirtyForRendering(wasDirty);
-		return nex.getRenderNodes()[0];
+		// wide so the contents don't wrap, out of flow so it doesn't disturb
+		// the real layout while it's up
+		let scratch = document.createElement('div');
+		scratch.style.visibility = 'hidden';
+		scratch.style.position = 'absolute';
+		scratch.style.top = '0';
+		scratch.style.left = '0';
+		scratch.style.width = '10000px';
+		document.body.appendChild(scratch);
+
+		try {
+			let hiddenRoot = this.createNewRoot({
+				mode: rendermode,
+				domNode: scratch
+			})
+
+			// render pass has to monotonically increase but it can skip, so when this is
+			// called, the main (visible) render pass number will skip numbers.
+			systemState.setGlobalRenderPassNumber(systemState.getGlobalRenderPassNumber() + 1);
+			// has to be synchronous so we can measure
+			hiddenRoot.render();
+			return measureFn(nex.getRenderNodes()[0]);
+		} finally {
+			// createNewRoot points systemState at whatever it just made, so the
+			// real root has to be put back
+			systemState.setRoot(savedRoot);
+			document.vodkaroot = savedDebugRoot;
+			document.body.removeChild(scratch);
+			// if it was dirty before, re-dirty it
+			nex.setDirtyForRendering(wasDirty);
+		}
 	}
 }
 


### PR DESCRIPTION
[17/18] — stacked on #318.

`#vodkaroot` was `height`/`width: 100%`, so it was exactly the viewport. A document taller than the window got a red line across it at the old bottom edge instead of a border around it. Now `min-height`/`min-width: 100%` with `width: fit-content` — never smaller than the window, grows to whatever the document needs. Same bug existed horizontally.

Also removes `#hiddenroot`, a permanently empty div that was still 10000px wide in the layout. It existed for `renderInHiddenRoot`, which nothing has called in a long time. That function now builds its own scratch node and disposes of it, so it takes a measure callback instead of returning a render node the caller can no longer measure once it is detached.

Two latent bugs fixed in the same path: `createNewRoot` ends with `systemState.setRoot`, so rendering into a hidden root pointed system state at the throwaway and never restored the real root, same for `document.vodkaroot`.

**Not verified visually** — this needs a rebuild and a document tall enough to scroll.