### PR TITLE
[18/21] Save audio alongside the document instead of inside it

### DIFF
--- a/server/src/audiocontainer.js
+++ b/server/src/audiocontainer.js
@@ -1,0 +1,162 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+A saved file that contains audio is a container: the document text, followed by
+the samples that document refers to, in one file.
+
+Wavetables serialize as an index instead of a base64 blob, and the sample list
+after the document supplies the bytes. The serializer mints the indices while
+walking the tree, so they are only meaningful inside the file they were written
+in -- nothing here is an identity that survives being copied somewhere else.
+See issue #319.
+
+Two things fall out of that, both for free:
+
+  - Nothing unreachable gets written. Only wavetables the walk actually reached
+    ever got the chance to hand over their samples.
+  - The same sample used twice is stored once, because add() dedupes on content.
+
+The header is length-prefixed rather than delimited, so no part of the document
+has to be escaped and no sentinel has to be picked that document text could
+never contain:
+
+    VODKAC1 <doclen> <len0> <len1> ...\n<doctext><b64 0><b64 1>...
+
+A document with no audio in it is written with no container at all. The common
+case stays byte-for-byte what earlier versions wrote, and files written before
+containers existed still load, because decode() passes anything without the
+magic straight through.
+*/
+
+const CONTAINER_MAGIC = 'VODKAC1';
+
+// String.fromCharCode is applied to slices rather than the whole array: a few
+// seconds of audio is a few hundred thousand samples, which is well past the
+// argument-count limit.
+const CHUNK = 0x8000;
+
+class AudioCollector {
+	constructor() {
+		this.samples = [];
+		this.indexByHash = {};
+	}
+
+	// returns the index the document should refer to
+	add(float32array, hash) {
+		if (hash in this.indexByHash) {
+			return this.indexByHash[hash];
+		}
+		let i = this.samples.length;
+		this.samples.push(float32array);
+		this.indexByHash[hash] = i;
+		return i;
+	}
+
+	isEmpty() {
+		return this.samples.length == 0;
+	}
+}
+
+function toBase64(float32array) {
+	let bytes = new Uint8Array(
+			float32array.buffer, float32array.byteOffset, float32array.byteLength);
+	let s = '';
+	for (let i = 0; i < bytes.length; i += CHUNK) {
+		s += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK));
+	}
+	return (typeof window !== 'undefined' && window.btoa)
+			? window.btoa(s)
+			: Buffer.from(s, 'binary').toString('base64');
+}
+
+function fromBase64(str) {
+	let s = (typeof window !== 'undefined' && window.atob)
+			? window.atob(str)
+			: Buffer.from(str, 'base64').toString('binary');
+	let bytes = new Uint8Array(s.length);
+	for (let i = 0; i < s.length; i++) {
+		bytes[i] = s.charCodeAt(i);
+	}
+	// A Float32Array needs whole samples. A truncated file would otherwise throw
+	// here and take the whole load down with it.
+	if (bytes.length % 4 != 0) {
+		return null;
+	}
+	return new Float32Array(bytes.buffer);
+}
+
+function encode(docText, collector) {
+	if (!collector || collector.isEmpty()) {
+		return docText;
+	}
+	let encoded = [];
+	for (let i = 0; i < collector.samples.length; i++) {
+		encoded.push(toBase64(collector.samples[i]));
+	}
+	let header = [ CONTAINER_MAGIC, docText.length ];
+	for (let i = 0; i < encoded.length; i++) {
+		header.push(encoded[i].length);
+	}
+	return header.join(' ') + '\n' + docText + encoded.join('');
+}
+
+/*
+Returns { docText, samples } for a container, or null for anything else -- a
+plain document, a server error string, a file from before containers existed.
+Callers treat null as "parse this as-is".
+
+A container that doesn't decode also comes back as null rather than throwing.
+That gets it parsed as a document, which fails with a parse error the user can
+see, instead of an exception on the way in.
+*/
+function decode(fileText) {
+	if (typeof fileText != 'string') return null;
+	if (fileText.indexOf(CONTAINER_MAGIC + ' ') != 0) return null;
+
+	let nl = fileText.indexOf('\n');
+	if (nl < 0) return null;
+
+	let fields = fileText.substring(0, nl).split(' ');
+	let lengths = [];
+	for (let i = 1; i < fields.length; i++) {
+		let n = Number(fields[i]);
+		if (!Number.isInteger(n) || n < 0) return null;
+		lengths.push(n);
+	}
+	// a doc length and at least one sample, or it wouldn't have been a container
+	if (lengths.length < 2) return null;
+
+	let total = nl + 1;
+	for (let i = 0; i < lengths.length; i++) {
+		total += lengths[i];
+	}
+	if (total != fileText.length) return null;
+
+	let pos = nl + 1;
+	let docText = fileText.substr(pos, lengths[0]);
+	pos += lengths[0];
+
+	let samples = [];
+	for (let i = 1; i < lengths.length; i++) {
+		samples.push(fromBase64(fileText.substr(pos, lengths[i])));
+		pos += lengths[i];
+	}
+	return { docText: docText, samples: samples };
+}
+
+export { AudioCollector, encode, decode }

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -60,8 +60,26 @@ let serializeAudioData = true;
 // the document. Chosen so it can't collide with base64, which has no colon.
 const AUDIO_REF_PREFIX = 'idb:';
 
+// Same idea, but the samples are in the same file, after the document. The
+// number is an index into that file's sample list and means nothing outside it.
+const AUDIO_INDEX_PREFIX = 'aud:';
+
+// Set while a file is being written: wavetables hand their samples over and
+// serialize as an index instead of inlining them. Set while a file is being
+// read, to turn those indices back into samples. See audiocontainer.js.
+let audioCollector = null;
+let audioReader = null;
+
 function setSerializeAudioData(v) {
 	serializeAudioData = v;
+}
+
+function setAudioCollector(c) {
+	audioCollector = c;
+}
+
+function setAudioReader(r) {
+	audioReader = r;
 }
 
 // A wavetable of DEFAULT_SIZE silent samples, encoded once. Emitting this rather
@@ -419,25 +437,36 @@ class Wavetable extends Nex {
 
 	}
 
+	// Referenced audio can be missing: storage cleared, quota evicted, a file
+	// truncated. Coming back as silence beats failing to restore the document at
+	// all. Length matters as well as presence -- a zero-length buffer is truthy,
+	// and a wavetable with no samples can't build an AudioBuffer, so it would
+	// throw on the way out of here.
+	setSamplesOrSilence(samples) {
+		if (!samples || samples.length == 0) {
+			samples = new Float32Array(DEFAULT_SIZE);
+		}
+		this.data = samples;
+		heap.requestMem(this.data.length * heap.incrementalSizeWavetable());
+		this.init();
+	}
+
 	deserializePrivateData(data) {
 		// A reference rather than the samples themselves, written by autosave.
 		// The lookup is synchronous because every record was read into memory
 		// during startup, before any document was built -- see audiostore.js.
 		if (data.indexOf(AUDIO_REF_PREFIX) == 0) {
-			let hash = data.substring(AUDIO_REF_PREFIX.length);
-			let samples = audioStore.get(hash);
-			if (!samples || samples.length == 0) {
-				// Referenced audio isn't there: storage was cleared, or the
-				// quota evicted it. Come back as silence rather than failing to
-				// restore the document at all. Length matters as well as
-				// presence -- a zero-length buffer is truthy, and a wavetable
-				// with no samples can't build an AudioBuffer, so it would throw
-				// on the way out of here.
-				samples = new Float32Array(DEFAULT_SIZE);
-			}
-			this.data = samples;
-			heap.requestMem(this.data.length * heap.incrementalSizeWavetable());
-			this.init();
+			this.setSamplesOrSilence(audioStore.get(data.substring(AUDIO_REF_PREFIX.length)));
+			return;
+		}
+		// Samples from elsewhere in this same file. audioReader is only set
+		// while a container is being read, so a document that refers to one
+		// outside that -- pasted somewhere, loaded by something that doesn't
+		// know about containers -- falls through to silence rather than to a
+		// stray lookup in whatever happens to be loaded.
+		if (data.indexOf(AUDIO_INDEX_PREFIX) == 0) {
+			let i = Number(data.substring(AUDIO_INDEX_PREFIX.length));
+			this.setSamplesOrSilence(audioReader ? audioReader(i) : null);
 			return;
 		}
 		// I don't know when this gets called?
@@ -459,6 +488,13 @@ class Wavetable extends Nex {
 	}
 
 	serializePrivateData() {
+		// Saving to a file: the samples go after the document and the document
+		// refers to them by index. Deduped on content, so the same sample used
+		// in twenty places is stored once.
+		if (audioCollector) {
+			return AUDIO_INDEX_PREFIX
+					+ audioCollector.add(this.data, audioStore.hashSamples(this.data));
+		}
 		// Autosave turns inline serialization off: sample data is far too large
 		// for localStorage (roughly 250KB of base64 per second of audio). The
 		// samples go to IndexedDB instead and what lands in the document is a
@@ -1160,4 +1196,4 @@ stats: ${heap.stats()}`)
 }
 
 
-export { Wavetable, WavetableEditor, constructWavetable, setSerializeAudioData }
+export { Wavetable, WavetableEditor, constructWavetable, setSerializeAudioData, setAudioCollector, setAudioReader }

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -82,6 +82,41 @@ function setAudioReader(r) {
 	audioReader = r;
 }
 
+/*
+Decodes samples stored directly in a document. Two formats have been written
+over the years: base64 of the raw Float32 bytes, and before that a list of
+decimal numbers separated by commas. Telling them apart is unambiguous because
+the base64 alphabet has no comma in it.
+
+Returns null instead of throwing. A wavetable that can't be decoded should cost
+you that one wavetable, not the whole document -- atob throws on malformed
+input, and a Float32Array needs a byte count divisible by four, so a truncated
+file used to take the entire load down with it.
+*/
+function parseInlineSamples(data) {
+	try {
+		if (data.indexOf(',') >= 0) {
+			let parts = data.split(',');
+			let out = new Float32Array(parts.length);
+			for (let i = 0; i < parts.length; i++) {
+				let n = Number(parts[i]);
+				if (!isFinite(n)) return null;
+				out[i] = n;
+			}
+			return out;
+		}
+		let s = window.atob(data);
+		let bytes = new Uint8Array(s.length);
+		for (let i = 0; i < s.length; i++) {
+			bytes[i] = s.charCodeAt(i);
+		}
+		if (bytes.length % 4 != 0) return null;
+		return new Float32Array(bytes.buffer);
+	} catch (e) {
+		return null;
+	}
+}
+
 // A wavetable of DEFAULT_SIZE silent samples, encoded once. Emitting this rather
 // than an empty string means a restored wavetable is structurally identical to a
 // freshly inserted one, instead of a zero-length oddity the renderer has never
@@ -469,22 +504,11 @@ class Wavetable extends Nex {
 			this.setSamplesOrSilence(audioReader ? audioReader(i) : null);
 			return;
 		}
-		// I don't know when this gets called?
-		let s = window.atob(data);
-		let len = s.length;
-		let bytes = new Uint8Array(len);
-		for (let i = 0; i < len; i++) {
-			bytes[i] = s.charCodeAt(i);
-		}
-		this.data = new Float32Array(bytes.buffer);
-		heap.requestMem(this.data.length * heap.incrementalSizeWavetable());
-		this.init();
-		// let sa = data.split(',');
-		// let d = [];
-		// for (let i = 0; i < sa.length; i++) {
-		// 	d[i] = Number(sa[i]);
-		// }
-		// this.initWith(d);
+		// The samples themselves, in the document. This is what every file saved
+		// before files became containers looks like, and autosave still writes
+		// it for the silence fallback when IndexedDB isn't available, so it is
+		// not a legacy path that can be dropped.
+		this.setSamplesOrSilence(parseInlineSamples(data));
 	}
 
 	serializePrivateData() {

--- a/server/src/servercommunication.js
+++ b/server/src/servercommunication.js
@@ -21,6 +21,8 @@ import { BINDINGS } from './environment.js'
 import { constructFatalError } from './nex/eerror.js'
 import { evaluateNexSafely } from './evaluator.js'
 import { parse } from './nexparser2.js';
+import { AudioCollector, encode as encodeContainer, decode as decodeContainer } from './audiocontainer.js';
+import { setAudioCollector, setAudioReader } from './nex/wavetable.js'
 import { systemState } from './systemstate.js'
 
 // polled by the test harness, which can't drive a request, only wait for it
@@ -117,7 +119,18 @@ function loadRaw(name, callback) {
 }
 
 function saveNex(name, nex, callback) {
-	let payload = `save\t${name}\t${'v2:' + nex.toString('v2')}`;
+	// The collector has to be up for the whole walk: wavetables hand their
+	// samples to it as they're reached, and it's the walk finishing that tells
+	// us which samples the document actually refers to.
+	let collector = new AudioCollector();
+	let docText;
+	setAudioCollector(collector);
+	try {
+		docText = 'v2:' + nex.toString('v2');
+	} finally {
+		setAudioCollector(null);
+	}
+	let payload = `save\t${name}\t${encodeContainer(docText, collector)}`;
 
 	sendToServer(payload, function(data) {
 		parseReturnPayload(data, callback);
@@ -167,10 +180,30 @@ function serverError() {
 }
 
 
+/*
+Everything that comes back from the server lands here: files, but also the small
+v2: replies to save and listfiles. Only a file can be a container, and decode()
+returns null for anything that isn't one, so the replies are untouched.
+*/
+function parseFileContents(data) {
+	let container = decodeContainer(data);
+	if (!container) {
+		return parse(data);
+	}
+	setAudioReader(function(i) {
+		return container.samples[i];
+	});
+	try {
+		return parse(container.docText);
+	} finally {
+		setAudioReader(null);
+	}
+}
+
 function parseReturnPayload(data, callback) {
 	let result = null;
 	try {
-		result = parse(data);
+		result = parseFileContents(data);
 	} catch (e) {
 		result = describeParseFailure(e);
 	}


### PR DESCRIPTION
[18/18] — stacked on #320.

A saved file with audio was the samples base64'd inline, roughly 235KB of text per second of audio. Unreadable, undiffable, and the same sample stored once per use.

Files are now containers: document text, then the samples it refers to. Wavetables serialize as `aud:<n>` and the sample list after the document supplies the bytes. Indices are minted during the walk and mean nothing outside the file — see #319.

Two properties fall out of the walk rather than needing code:
- nothing unreachable is written, because only wavetables the walk reached could hand samples over
- a sample used twice is stored once, deduped on content hash

The header is length-prefixed rather than delimited, so nothing needs escaping and there is no sentinel document text could accidentally contain.

**Backward compatible both ways.** A document with no audio is written with no container at all, so the ordinary case is byte-identical to before. Files written before this still load — `decode()` returns null for anything without the magic and the caller parses as-is. A damaged container also returns null rather than throwing, so it surfaces as a parse error.

## Testing

The container format is unit-tested standalone (15 cases: round trip, dedup, passthrough, truncation, bad header, document text containing the magic string and tabs and newlines). All pass.

**Not tested end-to-end in a browser** — a real save-then-load with a wavetable still needs checking by hand.