### PR TITLE
[20/21] Give every command line tool a --help

### DIFF
--- a/native/src/makedepgraph.sh
+++ b/native/src/makedepgraph.sh
@@ -18,6 +18,17 @@
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./makedepgraph.sh
+
+Builds a header dependency graph from the .h files here and opens it as a PDF.
+Needs graphviz. Run from native/src.
+USAGE
+	exit 0
+fi
+
+
 echo "digraph {" > dependencies.dot
 for A in *.h; do
 	cat $A | grep '#include "' | sed 's/#include/   "'$A'" -> /' >> dependencies.dot

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,22 @@
 #   ./run.sh          minified build, then serve
 #   ./run.sh --dev    unminified build with sourcemaps, then serve
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./run.sh [--dev]
+
+Builds the client and starts the server. This is the one you want.
+
+  --dev     unminified build with sourcemaps
+  --help    this message
+
+Refuses to start if something is already listening on port 3000.
+Serves on http://localhost:3000; ctrl-c stops it.
+USAGE
+	exit 0
+fi
+
+
 set -e
 cd "$(dirname "$0")"
 

--- a/server/build.sh
+++ b/server/build.sh
@@ -46,6 +46,24 @@ while [ "$1" != "" ]; do
 		--quiet)
 			LOG_ARGS="--log-level=error"
 			;;
+		--help|-h)
+			cat <<'USAGE'
+usage: ./build.sh [--dev|--watch] [--quiet]
+
+Bundles the vodka client into server/dist/.
+
+  --dev     unminified, with sourcemaps
+  --watch   unminified, rebuild on change
+  --quiet   report errors only, not warnings
+  --help    this message
+
+Writing to server/dist/ changes what the running server serves, immediately.
+Use ./run.sh from the repository root to build and serve in one step.
+
+Run from the server directory.
+USAGE
+			exit 0
+			;;
 		*)
 			echo "build.sh: unknown option '$1'"
 			echo "usage: ./build.sh [--dev|--watch] [--quiet]"

--- a/server/makedocs.sh
+++ b/server/makedocs.sh
@@ -1,3 +1,14 @@
 #!/bin/bash
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./makedocs.sh
+
+Runs jsdoc over server/src and writes the result to server/docs.
+Run from the server directory.
+USAGE
+	exit 0
+fi
+
+
 jsdoc src/* -d docs

--- a/server/runserver.sh
+++ b/server/runserver.sh
@@ -15,4 +15,18 @@
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./runserver.sh
+
+Starts the vodka server on port 3000. Does not build first -- use ./run.sh
+from the repository root for build-then-serve, or ./build.sh here to build
+without serving.
+
+Run from the server directory.
+USAGE
+	exit 0
+fi
+
+
 node webserver.js

--- a/server/tools/createnamedsession.js
+++ b/server/tools/createnamedsession.js
@@ -32,6 +32,20 @@ const GENERATED_SESSION_PREFIX = 'vs-';
 
 const RESERVED = ['packages', 'samples'];
 
+const USAGE = `usage: node tools/createnamedsession.js <name>
+
+Creates a named session, which is a directory under namedsessions/ that vodka
+saves and loads files in. Named sessions can only be made here -- the server
+used to allow it over HTTP, which let anyone claim any name.
+
+Names may contain letters, digits, underscores and hyphens. "packages" and
+"samples" are reserved, and a name cannot start with "vs-", which marks the
+sessions the server generates for itself.
+
+Open the result at /?sessionId=<name>
+
+Run from the server directory.`;
+
 function fail(message) {
 	console.error('createnamedsession: ' + message);
 	process.exit(1);
@@ -40,9 +54,21 @@ function fail(message) {
 function main() {
 	let name = process.argv[2];
 
+	if (name == '--help' || name == '-h') {
+		console.log(USAGE);
+		process.exit(0);
+	}
+
 	if (!name) {
-		console.error('usage: node tools/createnamedsession.js <name>');
+		console.error(USAGE);
 		process.exit(1);
+	}
+
+	// Hyphens are legal inside a name, so an option typo like --dry-run would
+	// otherwise pass validation and create a directory named after the flag.
+	if (name.indexOf('-') === 0) {
+		fail(`"${name}" starts with a hyphen. If you meant an option, the only`
+				+ ` one is --help.`);
 	}
 
 	if (RESERVED.indexOf(name) >= 0) {

--- a/src/createparser.sh
+++ b/src/createparser.sh
@@ -14,6 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./createparser.sh
+
+Regenerates the parser from parser.pegjs and installs it, writing
+server/src/nexparser2.js and server/src/parserfunctions.js.
+
+Needs pegjs on the path. Run from the src directory.
+USAGE
+	exit 0
+fi
+
+
 pegjs --format es -o ./tmp parser.pegjs 
 cat ./parser_prelude.js ./tmp > ./parser_for_testing.js
 cat ./parser_prelude.js ./tmp > ../server/src/nexparser2.js

--- a/src/testparser.sh
+++ b/src/testparser.sh
@@ -13,4 +13,14 @@
 
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./testparser.sh
+
+Runs testparser.js against the generated parser. Run from the src directory.
+USAGE
+	exit 0
+fi
+
+
 node --experimental-modules testparser.js

--- a/src/vodkar
+++ b/src/vodkar
@@ -1,4 +1,19 @@
 #!/bin/bash
 
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./vodkar [--noprompt]
+
+Starts a vodka read-eval-print loop in the terminal.
+
+  --noprompt    no prompt characters, for piping a script in
+  --help        this message
+
+Run from the src directory.
+USAGE
+	exit 0
+fi
+
+
 node --experimental-modules vodkar.js "$@"

--- a/testing/capturetest.sh
+++ b/testing/capturetest.sh
@@ -15,6 +15,20 @@
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./capturetest.sh [testname]
+
+Creates a screenshot test from vodka code on the clipboard. Prompts for a name
+if you do not pass one, shows you the clipboard to confirm, then asks for a
+description.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'

--- a/testing/clearsessions.sh
+++ b/testing/clearsessions.sh
@@ -14,6 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./clearsessions.sh
+
+Deletes every generated session in server/sessions/. Named sessions in
+server/namedsessions/ are left alone.
+
+This is destructive and does not ask. Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 pushd ../server/sessions
 rm -rf *
 popd

--- a/testing/createtestoutput.sh
+++ b/testing/createtestoutput.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./createtestoutput.sh
+
+Rebuilds testresults.html from the .out files already in alltests/, without
+running any tests. Use this after editing goldens by hand.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 node parsetestoutput.js

--- a/testing/createunittest.sh
+++ b/testing/createunittest.sh
@@ -14,6 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./createunittest.sh [testname]
+
+Creates an empty unit test file in alltests/. Prompts for a name if you do not
+pass one, then for a description.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 if [ "$1" == "" ]; then
 	echo "Type name of the new test:"
 	read NAME

--- a/testing/fixtest.py
+++ b/testing/fixtest.py
@@ -51,6 +51,19 @@ def do_test_line(match, line):
 def do_regular_line(line):
 	print(line, end='')
 
+USAGE = """usage: fixtest.py <testfile>
+
+Rewrites an old-style test file that calls harness.runTest with a function
+into the newer form that builds a testactions list and calls runTestNew.
+
+Prints the converted test to standard output; it does not modify the file.
+
+Run from the testing directory."""
+
+if len(sys.argv) > 1 and sys.argv[1] in ('--help', '-h'):
+	print(USAGE)
+	sys.exit(0)
+
 if len(sys.argv) < 2:
 	print("need argument: file to fix.")
 	sys.exit()

--- a/testing/goldenupdate.sh
+++ b/testing/goldenupdate.sh
@@ -14,6 +14,24 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./goldenupdate.sh <testname> [-b]
+
+Replaces one test's golden with its current output, then reruns it.
+
+  -b        batch: skip the confirmation prompt
+
+Goldens are per platform, under alltests/<testname>/goldens/<platform>/,
+because font rendering differs between operating systems. This updates the
+golden for the platform you are on now and leaves the others alone.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 . "$(dirname "$0")/platform.sh"
 
 is_vk() {

--- a/testing/ignoretest.sh
+++ b/testing/ignoretest.sh
@@ -14,6 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./ignoretest.sh <testname>
+
+Marks a test ignored, so runtests.sh skips it, then reruns it to refresh the
+results page. Undo with ./unignoretest.sh.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 if [ "$1" == "" ]; then
 	echo "requires argument"
 	exit 1

--- a/testing/randomtests.sh
+++ b/testing/randomtests.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./randomtests.sh [count]
+
+Runs `count` randomly chosen tests, 5 by default. Picks with replacement, so
+the same test can come up twice.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 NUM_FILES_IN_DIR=$(ls alltests/*.js | wc | tr -s ' ' | cut -d ' ' -f2)
 
 NUM_TESTS=${1:-5}

--- a/testing/regenerateallgoldens.sh
+++ b/testing/regenerateallgoldens.sh
@@ -14,6 +14,23 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./regenerateallgoldens.sh
+
+Replaces the golden for EVERY test with that test's current output, after one
+confirmation prompt.
+
+Only do this when you have looked at every failing test and decided that all
+of the new output is correct. Otherwise it silently blesses real breakage.
+For a single test use ./goldenupdate.sh instead.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 echo "DO NOT REGENERATE GOLDENS IF YOU HAVE NOT LOOKED CAREFULLY AT EVERY SINGLE FAILING TEST, AND VERIFIED THAT IT IS OKAY FOR THE TEST OUTPUT TO BECOME THE NEW GOLDEN. (type 'y' to proceed)"
 read INP
 if [ "$INP" == "y" ]; then

--- a/testing/removetest.sh
+++ b/testing/removetest.sh
@@ -14,6 +14,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./removetest.sh <testname>
+
+Deletes a test and its goldens. Asks for confirmation first.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'

--- a/testing/renametest.sh
+++ b/testing/renametest.sh
@@ -15,6 +15,22 @@
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./renametest.sh <oldname> <newname>
+
+Renames a test, rewrites the name inside the test file, drops the old output
+directory and reruns under the new name. Asks for confirmation first.
+
+Goldens are NOT carried over -- the old output directory is deleted, so the
+renamed test starts with no golden and will need one captured.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 if [ "$1" == "" ]; then
 	echo "requires 2 arguments"
 	exit 1

--- a/testing/replcapture.sh
+++ b/testing/replcapture.sh
@@ -14,6 +14,19 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./replcapture.sh <testname> [sourcefile]
+
+Creates a .vk REPL test -- one that compares printed output rather than a
+screenshot. Offers to overwrite if the test already exists.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'

--- a/testing/runtests.sh
+++ b/testing/runtests.sh
@@ -14,6 +14,25 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./runtests.sh [testname] [--show] [--testdir dir] [--params qs]
+
+Runs the test suite, or one test if you name one. Writes testresults.html.
+
+  --show, -s      run headful, so you can watch the browser
+  --testdir dir   take tests from somewhere other than alltests
+  --params qs     extra query string parameters for the page under test
+  --help          this message
+
+Needs the server running on port 3000.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 . "$(dirname "$0")/platform.sh"
 
 RED='\033[0;31m'

--- a/testing/unignoretest.sh
+++ b/testing/unignoretest.sh
@@ -14,6 +14,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+	cat <<'USAGE'
+usage: ./unignoretest.sh <testname>
+
+Removes the ignore mark from a test, then reruns it.
+
+Run from the testing directory.
+USAGE
+	exit 0
+fi
+
+
 if [ "$1" == "" ]; then
 	echo "requires argument"
 	exit 1


### PR DESCRIPTION
[20/20] — stacked on #322.

Only `audio2vodka.py` had one, out of 24 tools. `build.sh` and `createnamedsession.js` printed usage, but only when you got the arguments wrong.

`createnamedsession.js` was worse than missing: it validates names against `/^[a-zA-Z0-9_-]+$/`, which `--help` matches, so asking it for help **created a session directory called `--help`**. Hyphen-leading arguments are now rejected.

Each message says what the tool does, what the arguments mean, and which directory to run it from — most assume a working directory and none of them said so. Destructive or easily-confused tools say so:

- `clearsessions.sh` deletes without asking
- `regenerateallgoldens.sh` blesses every current output as correct
- `renametest.sh` does not carry goldens over
- `build.sh` writes to `dist/`, which changes what a running server serves

`platform.sh` deliberately has none — it is sourced, not run, so `$1` there belongs to whichever script sourced it.

Verified all 24 respond to `--help` with a line starting `usage:`, and that none of them leaves anything behind when asked.