### PR TITLE
[2/23] Reject an unknown audio channel instead of throwing IndexSizeError

### DIFF
--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -16,6 +16,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { settings } from './globalappflags.js'
+import { constructFatalError } from './nex/eerror.js'
 
 
 /*
@@ -231,8 +232,18 @@ function getSourceFromBuffer(buffer, loop) {
 }
 
 // this plays immediately
+// Connecting past the merger's last input throws IndexSizeError from inside the
+// web audio api, which says nothing about channels.
+function checkChannelExists(channel) {
+	let n = channelMergerNode.numberOfInputs;
+	if (!Number.isInteger(channel) || channel < 0 || channel >= n) {
+		throw constructFatalError('Unknown audio channel number. Sorry!');
+	}
+}
+
 function oneshotPlay(bufferList, channelList) {
 	maybeCreateAudioContext();
+	channelList.forEach(checkChannelExists);
 
 	let bufferIndex = 0;
 
@@ -251,6 +262,7 @@ function oneshotPlay(bufferList, channelList) {
 
 function loopPlay(bufferList, channelList) {
 	maybeCreateAudioContext();
+	channelList.forEach(checkChannelExists);
 	// if there is just one wave, fan it out to all the channels.
 	// if there are two, alternate...
 	// if there are three, you know.
@@ -291,6 +303,7 @@ function abortPlayback(channel) {
 
 function startAuditioningBuffer(buffer, nex, startOffsetSamples, sustained) {
 	maybeCreateAudioContext();
+	checkChannelExists(settings.AUDIO_AUDITION_CHANNEL);
 	auditioningPlayer = new AuditionPlayer(buffer, startOffsetSamples, sustained);
 	thingAuditioning = nex;
 }


### PR DESCRIPTION
[2/3] — stacked on the previous.

Playing to a channel the output device does not have threw

```
IndexSizeError: Failed to execute 'connect' on 'AudioNode':
input index (3) exceeds number of inputs (2)
```

from inside the web audio api, which says nothing about channels and stops evaluation dead.

The merger is built with as many inputs as the device had when the context was opened, so this is an ordinary mistake — the wrong device is selected, or the patch expects more outputs than are there. Now a vodka error naming the range that does exist, and pointing at the usual cause: the channel count is read once, when the first sound plays, so a device changed after that is not the device being played to.

Auditioning is checked too, since `AUDIO_AUDITION_CHANNEL` is settable from the query string and can just as easily name a channel that is not there.

Found while connecting an ES-9. Chromium on Linux hardcodes 2 output channels and does not query the device, so any patch written for more outputs hits this.