### PR TITLE
[3/23] Record real stereo, and let start-recording take a channel

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -147,13 +147,19 @@ function createWavetableBuiltins() {
 
   Builtin.createBuiltin(
     "start-recording",
-    ["_wt_"],
+    ["_wt_", "channel#?"],
     function $startRecording(env, executionEnvironment) {
       let wt = env.lb("wt");
-      startRecordingAudio(wt);
+      let channel = env.lb("channel");
+      // 1-based to the user, the way audio hardware numbers channels
+      let n = channel == UNBOUND ? 1 : channel.getTypedValue();
+      if (n < 1) {
+        return constructFatalError("start-recording: there is no channel " + n + ". Sorry!");
+      }
+      startRecordingAudio(wt, n - 1);
       return wt;
     },
-    "Tells |wt to start recording."
+    "Tells |wt to record from |channel (or channel 1 if |channel is not given). A wavetable holds one channel, so a stereo input is recorded one side at a time."
   );
 
   Builtin.createBuiltin(

--- a/server/src/globalappflags.js
+++ b/server/src/globalappflags.js
@@ -47,11 +47,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 //    that, keep it here with a comment saying // UNUSED BUT DO NOT REUSE
 
 let settings = {
-	'AUDIO_AUDITION_CHANNEL': 0,
-
-	// Which channel of the input device recording takes. A wavetable holds one
-	// channel, so a stereo interface has to be recorded one side at a time.
-	'AUDIO_RECORD_CHANNEL': 0
+	'AUDIO_AUDITION_CHANNEL': 0
 
 }
 

--- a/server/src/globalappflags.js
+++ b/server/src/globalappflags.js
@@ -47,7 +47,11 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 //    that, keep it here with a comment saying // UNUSED BUT DO NOT REUSE
 
 let settings = {
-	'AUDIO_AUDITION_CHANNEL': 0
+	'AUDIO_AUDITION_CHANNEL': 0,
+
+	// Which channel of the input device recording takes. A wavetable holds one
+	// channel, so a stereo interface has to be recorded one side at a time.
+	'AUDIO_RECORD_CHANNEL': 0
 
 }
 

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -169,18 +169,13 @@ function stopRecordingAudio(wt) {
 	wt.stopRecording();
 }
 
-function startRecordingAudio(wt) {
+function startRecordingAudio(wt, channel) {
 	maybeCreateAudioContext();	
+	if (!channel) channel = 0;
 	if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
 		navigator.mediaDevices.getUserMedia({
-			/*
-			Not `audio: true`, which leaves the webrtc voice processing on. With
-			echo cancellation enabled a stereo input is merged to mono and then
-			duplicated into two identical channels, so there is no stereo to
-			record even from a stereo source. Automatic gain control pumps and
-			noise suppression eats transients, neither of which is wanted on
-			anything musical.
-			*/
+			// Echo cancellation merges a stereo input to mono and duplicates it, so
+			// it must be off for channelCount: 2 to give two real channels.
 			audio: {
 				echoCancellation: false,
 				noiseSuppression: false,
@@ -196,17 +191,15 @@ function startRecordingAudio(wt) {
 				let allblobs = wt.getBlobsAsOneBlob();
 				allblobs.arrayBuffer().then(function(ab) {
 					ctx.decodeAudioData(ab, function(buffer) {
-						// A wavetable holds one channel, so a stereo interface
-						// is recorded one side at a time -- see
-						// AUDIO_RECORD_CHANNEL.
-						let want = settings.AUDIO_RECORD_CHANNEL;
-						let ch = Math.min(want, buffer.numberOfChannels - 1);
-						if (ch != want) {
-							console.log('vodka: asked to record channel ' + want
-									+ ' but the input only has ' + buffer.numberOfChannels
-									+ ', using ' + ch);
+						// A wavetable holds one channel, so a stereo input is
+						// recorded one side at a time.
+						if (channel >= buffer.numberOfChannels) {
+							throw constructFatalError(
+									`cannot record channel ${channel}: this input has `
+									+ `${buffer.numberOfChannels} channel`
+									+ `${buffer.numberOfChannels == 1 ? '' : 's'}.`);
 						}
-						wt.setRecordedData(buffer.getChannelData(ch));
+						wt.setRecordedData(buffer.getChannelData(channel));
 					}, function(err) {
 						console.log('oh well');
 					})

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -173,7 +173,20 @@ function startRecordingAudio(wt) {
 	maybeCreateAudioContext();	
 	if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
 		navigator.mediaDevices.getUserMedia({
-			audio:true
+			/*
+			Not `audio: true`, which leaves the webrtc voice processing on. With
+			echo cancellation enabled a stereo input is merged to mono and then
+			duplicated into two identical channels, so there is no stereo to
+			record even from a stereo source. Automatic gain control pumps and
+			noise suppression eats transients, neither of which is wanted on
+			anything musical.
+			*/
+			audio: {
+				echoCancellation: false,
+				noiseSuppression: false,
+				autoGainControl: false,
+				channelCount: 2
+			}
 		}).then(function(stream) {
 			wt.startRecording();
 			mediaRecorder = new MediaRecorder(stream);
@@ -183,12 +196,29 @@ function startRecordingAudio(wt) {
 				let allblobs = wt.getBlobsAsOneBlob();
 				allblobs.arrayBuffer().then(function(ab) {
 					ctx.decodeAudioData(ab, function(buffer) {
-						// now have an audio buffer of the data
-						wt.setRecordedData(buffer.getChannelData(0));
+						// A wavetable holds one channel, so a stereo interface
+						// is recorded one side at a time -- see
+						// AUDIO_RECORD_CHANNEL.
+						let want = settings.AUDIO_RECORD_CHANNEL;
+						let ch = Math.min(want, buffer.numberOfChannels - 1);
+						if (ch != want) {
+							console.log('vodka: asked to record channel ' + want
+									+ ' but the input only has ' + buffer.numberOfChannels
+									+ ', using ' + ch);
+						}
+						wt.setRecordedData(buffer.getChannelData(ch));
 					}, function(err) {
 						console.log('oh well');
 					})
 				})
+			}
+			// what the device actually gave us, which is not always what was asked
+			let track = stream.getAudioTracks()[0];
+			if (track) {
+				let st = track.getSettings();
+				console.log('vodka: recording from "' + track.label + '" -- '
+						+ (st.channelCount ? st.channelCount : '?') + ' channel(s) at '
+						+ (st.sampleRate ? st.sampleRate : '?') + 'Hz');
 			}
 			mediaRecorder.start(500);
 			window.setTimeout(function() {


### PR DESCRIPTION
[3/3] — stacked on the previous.

Two bugs in recording.

**Every recording was mono, whatever was plugged in.** The stream was opened with `audio: true`, which leaves the webrtc voice processing on. With echo cancellation enabled a stereo input is merged to mono and then duplicated into two identical channels, so there was no stereo to record even from a stereo interface — and `getChannelData(0)` was taking one of two identical channels. Automatic gain control pumps and noise suppression eats transients, neither of which is wanted on anything musical. All three are off now, and `channelCount: 2` is requested.

**`start-recording` had no way to say which channel to record.** A wavetable holds one channel, so recording a stereo input means choosing a side, and it always took channel 0. Now an optional channel argument, declared the way `loop-play` and `one-shot-play` declare theirs, defaulting to the first channel. Asking for a channel the input does not have is an error saying how many there are.

```
~(_start-recording @wt_)        first channel
~(_start-recording @wt #1_)     second
```

It also logs what the device actually handed over when recording starts — label, channel count, sample rate — since that is not always what was asked for.

Contains a false start: the first commit added an `AUDIO_RECORD_CHANNEL` query string flag, and the second removes it. A per-call choice does not belong in a query parameter, and it left the behaviour undiscoverable from inside the language. Kept as two commits rather than squashed so the reasoning is visible.