### PR TITLE
[4/4] List every midi port instead of only the inputs

### DIFF
--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,9 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiPorts } from '../midifunctions.js'
+import { getMidiPorts, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+		 sendMidiNoteWithDuration } from '../midifunctions.js'
+import { convertTimeToSamples, nexToTimebase, getSampleRate } from '../wavetablefunctions.js'
 import { constructOrg } from '../nex/org.js'; 
 import { constructDeferredValue } from '../nex/deferredvalue.js'; 
 import { constructFatalError, constructInfo, newTagOrThrowOOM } from '../nex/eerror.js'
@@ -61,6 +63,133 @@ function createMidiBuiltins() {
 		'Lists every midi port, in both directions. Each port is tagged |midiport, and its |type says whether it is an input or an output.'
 	);
 
+
+
+	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
+
+	/*
+	Shared by both send builtins: a port org came from list-midi-ports, so it
+	carries the id the browser knows it by, and says which direction it is.
+	*/
+	function portIdOrError(port, who) {
+		if (!port.hasTag(newTagOrThrowOOM('midiport', who + ', is midi port'))) {
+			return { error: constructFatalError(who + ': that is not a midi port. Use list-midi-ports.') };
+		}
+		let type = port.getChildTagged(newTagOrThrowOOM('type', who + ', type'));
+		if (type && type.getFullTypedValue() != 'output') {
+			return { error: constructFatalError(who + ': that is an input port. Midi is sent to outputs.') };
+		}
+		let id = port.getChildTagged(newTagOrThrowOOM('id', who + ', id'));
+		if (!id) {
+			return { error: constructFatalError(who + ': that midi port has no id.') };
+		}
+		return { id: id.getFullTypedValue() };
+	}
+
+	function taggedInt(org, name, who) {
+		let c = org.getChildTagged(newTagOrThrowOOM(name, who + ', ' + name));
+		return c ? c.getTypedValue() : null;
+	}
+
+	Builtin.createBuiltin(
+		'send-midi-data on',
+		[ 'data()', 'port()' ],
+		function $sendMidiData(env, executionEnvironment) {
+			let data = env.lb('data');
+			let port = portIdOrError(env.lb('port'), 'send-midi-data');
+			if (port.error) return port.error;
+
+			let bytes = [];
+			for (let i = 0; i < data.numChildren(); i++) {
+				let b = data.getChildAt(i).getTypedValue();
+				if (!Number.isInteger(b) || b < 0 || b > 255) {
+					return constructFatalError(
+							`send-midi-data: ${b} is not a byte. Midi data is whole numbers from 0 to 255.`);
+				}
+				bytes.push(b);
+			}
+			if (bytes.length == 0) {
+				return constructFatalError('send-midi-data: nothing to send.');
+			}
+			sendMidiData(port.id, bytes);
+			return data;
+		},
+		'Sends |data, an org of integers, to the midi port |port exactly as given. For anything the note builtin does not cover -- control changes, program changes, clock, sysex.'
+	);
+
+	/*
+	The tag on the integer says what kind of message this is, the same way a tag
+	on a number says what timebase it is in. `note` is a note with a duration,
+	which sends the note on now and schedules the note off; `note-on` and
+	`note-off` are the halves on their own, for an instrument where something
+	else decides when the note ends.
+
+	Deliberately no converting between a note off and a note on at velocity
+	zero. Devices differ, and note off velocity means release velocity on some
+	of them, so the two are not interchangeable. Writing `note-on` with a
+	velocity of 0 gives the second form if that is what a device wants.
+	*/
+	Builtin.createBuiltin(
+		'send-midi-note on',
+		[ 'note()', 'port()' ],
+		function $sendMidiNote(env, executionEnvironment) {
+			let n = env.lb('note');
+			let port = portIdOrError(env.lb('port'), 'send-midi-note');
+			if (port.error) return port.error;
+
+			let kind = null;
+			let notenum = null;
+			for (let k of ['note', 'note-on', 'note-off']) {
+				let v = taggedInt(n, k, 'send-midi-note');
+				if (v !== null) {
+					kind = k;
+					notenum = v;
+					break;
+				}
+			}
+			if (kind == null) {
+				return constructFatalError(
+						'send-midi-note: needs an integer tagged note, note-on or note-off.');
+			}
+			if (notenum < 0 || notenum > 127) {
+				return constructFatalError(
+						`send-midi-note: ${notenum} is not a midi note. Notes run from 0 to 127.`);
+			}
+
+			let velocity = taggedInt(n, 'velocity', 'send-midi-note');
+			if (velocity == null) velocity = 127;
+			if (velocity < 0 || velocity > 127) {
+				return constructFatalError(
+						`send-midi-note: velocity ${velocity} is out of range. Velocity runs from 0 to 127.`);
+			}
+
+			// 1-16, the way hardware shows them
+			let channel = taggedInt(n, 'channel', 'send-midi-note');
+			if (channel == null) channel = 1;
+			if (channel < 1 || channel > 16) {
+				return constructFatalError(
+						`send-midi-note: there is no channel ${channel}. Midi channels run from 1 to 16.`);
+			}
+
+			if (kind == 'note-on') {
+				sendMidiNoteOn(port.id, channel, notenum, velocity);
+			} else if (kind == 'note-off') {
+				sendMidiNoteOff(port.id, channel, notenum, velocity);
+			} else {
+				let dur = n.getChildTagged(newTagOrThrowOOM('duration', 'send-midi-note, duration'));
+				if (!dur) {
+					return constructFatalError(
+							'send-midi-note: a note tagged `note` needs a duration. Tag one with note-on '
+							+ 'and send a note-off yourself if you do not know how long it lasts.');
+				}
+				let timebase = nexToTimebase(dur);
+				let ms = (convertTimeToSamples(dur, timebase) / getSampleRate()) * 1000;
+				sendMidiNoteWithDuration(port.id, channel, notenum, velocity, ms, timebase == 'BEATS');
+			}
+			return n;
+		},
+		'Sends a midi note to the port |port. |note is an org holding an integer tagged note, note-on or note-off. A note tagged |note also needs a float tagged duration, which takes a timebase tag like any other length. Velocity defaults to 127 and channel to 1.'
+	);
 
 	Builtin.createBuiltin(
 		'wait-for-midi',

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -67,21 +67,17 @@ function createMidiBuiltins() {
 
 	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
 
-	/*
-	Shared by both send builtins: a port org came from list-midi-ports, so it
-	carries the id the browser knows it by, and says which direction it is.
-	*/
 	function portIdOrError(port, who) {
 		if (!port.hasTag(newTagOrThrowOOM('midiport', who + ', is midi port'))) {
-			return { error: constructFatalError(who + ': that is not a midi port. Use list-midi-ports.') };
+			return { error: constructFatalError(who + ': not a midi port. Sorry!') };
 		}
 		let type = port.getChildTagged(newTagOrThrowOOM('type', who + ', type'));
 		if (type && type.getFullTypedValue() != 'output') {
-			return { error: constructFatalError(who + ': that is an input port. Midi is sent to outputs.') };
+			return { error: constructFatalError(who + ': that is an input port. Sorry!') };
 		}
 		let id = port.getChildTagged(newTagOrThrowOOM('id', who + ', id'));
 		if (!id) {
-			return { error: constructFatalError(who + ': that midi port has no id.') };
+			return { error: constructFatalError(who + ': midi port has no id. Sorry!') };
 		}
 		return { id: id.getFullTypedValue() };
 	}
@@ -109,9 +105,7 @@ function createMidiBuiltins() {
 					openMidiPort(idstr, function(desc) {
 						if (!desc) {
 							callback(constructFatalError(
-									`open-midi-port: there is no port with id ${idstr} any more. `
-									+ `It may have been unplugged -- call list-midi-ports to see `
-									+ `what is there now.`));
+									`open-midi-port: no port with id ${idstr}. Sorry!`));
 							return;
 						}
 						let org = convertJSMapToOrg(desc);
@@ -141,13 +135,12 @@ function createMidiBuiltins() {
 			for (let i = 0; i < data.numChildren(); i++) {
 				let b = data.getChildAt(i).getTypedValue();
 				if (!Number.isInteger(b) || b < 0 || b > 255) {
-					return constructFatalError(
-							`send-midi-data: ${b} is not a byte. Midi data is whole numbers from 0 to 255.`);
+					return constructFatalError(`send-midi-data: ${b} is not a byte (0-255). Sorry!`);
 				}
 				bytes.push(b);
 			}
 			if (bytes.length == 0) {
-				return constructFatalError('send-midi-data: nothing to send.');
+				return constructFatalError('send-midi-data: nothing to send. Sorry!');
 			}
 			sendMidiData(port.id, bytes);
 			return data;
@@ -155,18 +148,9 @@ function createMidiBuiltins() {
 		'Sends |data, an org of integers, to the midi port |port exactly as given. For anything the note builtin does not cover -- control changes, program changes, clock, sysex.'
 	);
 
-	/*
-	The tag on the integer says what kind of message this is, the same way a tag
-	on a number says what timebase it is in. `note` is a note with a duration,
-	which sends the note on now and schedules the note off; `note-on` and
-	`note-off` are the halves on their own, for an instrument where something
-	else decides when the note ends.
-
-	Deliberately no converting between a note off and a note on at velocity
-	zero. Devices differ, and note off velocity means release velocity on some
-	of them, so the two are not interchangeable. Writing `note-on` with a
-	velocity of 0 gives the second form if that is what a device wants.
-	*/
+	// The tag on the int picks the message, like a timebase tag picks a unit.
+	// No converting note-off to note-on-at-zero: note off velocity is release
+	// velocity on some devices, so they aren't interchangeable.
 	Builtin.createBuiltin(
 		'send-midi-note on',
 		[ 'note()', 'port()' ],
@@ -187,26 +171,23 @@ function createMidiBuiltins() {
 			}
 			if (kind == null) {
 				return constructFatalError(
-						'send-midi-note: needs an integer tagged note, note-on or note-off.');
+						'send-midi-note: needs an int tagged note, note-on or note-off. Sorry!');
 			}
 			if (notenum < 0 || notenum > 127) {
-				return constructFatalError(
-						`send-midi-note: ${notenum} is not a midi note. Notes run from 0 to 127.`);
+				return constructFatalError(`send-midi-note: ${notenum} is not a note (0-127). Sorry!`);
 			}
 
 			let velocity = taggedInt(n, 'velocity', 'send-midi-note');
 			if (velocity == null) velocity = 127;
 			if (velocity < 0 || velocity > 127) {
-				return constructFatalError(
-						`send-midi-note: velocity ${velocity} is out of range. Velocity runs from 0 to 127.`);
+				return constructFatalError(`send-midi-note: velocity ${velocity} is out of range (0-127). Sorry!`);
 			}
 
 			// 1-16, the way hardware shows them
 			let channel = taggedInt(n, 'channel', 'send-midi-note');
 			if (channel == null) channel = 1;
 			if (channel < 1 || channel > 16) {
-				return constructFatalError(
-						`send-midi-note: there is no channel ${channel}. Midi channels run from 1 to 16.`);
+				return constructFatalError(`send-midi-note: no channel ${channel} (1-16). Sorry!`);
 			}
 
 			if (kind == 'note-on') {
@@ -216,9 +197,7 @@ function createMidiBuiltins() {
 			} else {
 				let dur = n.getChildTagged(newTagOrThrowOOM('duration', 'send-midi-note, duration'));
 				if (!dur) {
-					return constructFatalError(
-							'send-midi-note: a note tagged `note` needs a duration. Tag one with note-on '
-							+ 'and send a note-off yourself if you do not know how long it lasts.');
+					return constructFatalError('send-midi-note: a note needs a duration. Sorry!');
 				}
 				let timebase = nexToTimebase(dur);
 				let ms = (convertTimeToSamples(dur, timebase) / getSampleRate()) * 1000;
@@ -243,12 +222,10 @@ function createMidiBuiltins() {
 			// by mistake, and listening to one just never fires
 			let type = midiport.getChildTagged(newTagOrThrowOOM('type', 'wait for midi builtin, type'));
 			if (type && type.getFullTypedValue() != 'input') {
-				return constructFatalError(
-						'wait-for-midi: that is an output port. Only input ports receive midi.');
+				return constructFatalError('wait-for-midi: that is an output port. Sorry!');
 			}
 			if (!isPortOpen(id.getTypedValue())) {
-				return constructFatalError(
-						'wait-for-midi: that midi port is not open. Pass it to open-midi-port first.');
+				return constructFatalError('wait-for-midi: you must open the midi port first. Sorry!');
 			}
 			let dv = constructDeferredValue();
 			dv.setAutoreset(true);

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiDevices } from '../midifunctions.js'
+import { getMidiPorts } from '../midifunctions.js'
 import { constructOrg } from '../nex/org.js'; 
 import { constructDeferredValue } from '../nex/deferredvalue.js'; 
 import { constructFatalError, constructInfo, newTagOrThrowOOM } from '../nex/eerror.js'
@@ -30,32 +30,32 @@ import {
 
 function createMidiBuiltins() {
 	Builtin.createBuiltin(
-		'list-midi-inputs',
+		'list-midi-ports',
 		[ ],
 		function $listMidiInputs(env, executionEnvironment) {
 			let dv = constructDeferredValue();
 			dv.set(new GenericActivationFunctionGenerator(
-				'list-midi-inputs', 
+				'list-midi-ports', 
 				function(callback, exp) {
-					getMidiDevices(function(devs) {
+					getMidiPorts(function(devs) {
 						// devices will just be a string
 						// convert to nice estrings
 						let r = constructOrg();
 						for (let i = 0; i < devs.length ; i++) {
 							let org = convertJSMapToOrg(devs[i]);
 							org.setHorizontal();
-							org.addTag(newTagOrThrowOOM('midiport', 'list midi imputs builtin'));
+							org.addTag(newTagOrThrowOOM('midiport', 'list midi ports builtin'));
 							r.appendChild(org);
 						}
 						callback(r);
 					})
 				}
 			));
-			let waitmessage = constructInfo(`listing midi inputs`);
+			let waitmessage = constructInfo(`listing midi ports`);
 			dv.appendChild(waitmessage)
 			return dv;
 		},
-		'Lists midi inputs.'
+		'Lists every midi port, in both directions. Each port is tagged |midiport, and its |type says whether it is an input or an output.'
 	);
 
 
@@ -68,6 +68,13 @@ function createMidiBuiltins() {
 			let id = midiport.getChildTagged(newTagOrThrowOOM('id', 'wait for midi builtin, id'));
 			if (!ismidiport || !id) {
 				return constructFatalError('wait-for-midi: must pass in a midiport object with a valid ID');
+			}
+			// now that both directions are listed, an output can be passed here
+			// by mistake, and listening to one just never fires
+			let type = midiport.getChildTagged(newTagOrThrowOOM('type', 'wait for midi builtin, type'));
+			if (type && type.getFullTypedValue() != 'input') {
+				return constructFatalError(
+						'wait-for-midi: that is an output port. Only input ports receive midi.');
 			}
 			let dv = constructDeferredValue();
 			dv.setAutoreset(true);

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -53,6 +53,9 @@ function createMidiBuiltins() {
 			));
 			let waitmessage = constructInfo(`listing midi ports`);
 			dv.appendChild(waitmessage)
+			// without this the activation function never runs: the deferred sits
+			// showing its wait message forever, never having asked for anything
+			dv.activate();
 			return dv;
 		},
 		'Lists every midi port, in both directions. Each port is tagged |midiport, and its |type says whether it is an input or an output.'

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiPorts, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+import { getMidiPorts, openMidiPort, isPortOpen, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
 		 sendMidiNoteWithDuration } from '../midifunctions.js'
 import { convertTimeToSamples, nexToTimebase, getSampleRate } from '../wavetablefunctions.js'
 import { constructOrg } from '../nex/org.js'; 
@@ -90,6 +90,44 @@ function createMidiBuiltins() {
 		let c = org.getChildTagged(newTagOrThrowOOM(name, who + ', ' + name));
 		return c ? c.getTypedValue() : null;
 	}
+
+	Builtin.createBuiltin(
+		'open-midi-port',
+		[ 'port()' ],
+		function $openMidiPort(env, executionEnvironment) {
+			let port = env.lb('port');
+			let id = port.getChildTagged(newTagOrThrowOOM('id', 'open midi port, id'));
+			if (!port.hasTag(newTagOrThrowOOM('midiport', 'open midi port, is midi port')) || !id) {
+				return constructFatalError('open-midi-port: must pass in a midiport object with a valid ID');
+			}
+			let idstr = id.getFullTypedValue();
+
+			let dv = constructDeferredValue();
+			dv.set(new GenericActivationFunctionGenerator(
+				'open-midi-port',
+				function(callback, exp) {
+					openMidiPort(idstr, function(desc) {
+						if (!desc) {
+							callback(constructFatalError(
+									`open-midi-port: there is no port with id ${idstr} any more. `
+									+ `It may have been unplugged -- call list-midi-ports to see `
+									+ `what is there now.`));
+							return;
+						}
+						let org = convertJSMapToOrg(desc);
+						org.setHorizontal();
+						org.addTag(newTagOrThrowOOM('midiport', 'open midi port builtin'));
+						callback(org);
+					})
+				}
+			));
+			let waitmessage = constructInfo(`opening midi port`);
+			dv.appendChild(waitmessage)
+			dv.activate();
+			return dv;
+		},
+		'Reconnects the midi port |port and returns it with its state as it is now. A port remembered from a previous session is only its name and id until this is called; list-midi-ports does the same thing for every port at once.'
+	);
 
 	Builtin.createBuiltin(
 		'send-midi-data on',
@@ -207,6 +245,10 @@ function createMidiBuiltins() {
 			if (type && type.getFullTypedValue() != 'input') {
 				return constructFatalError(
 						'wait-for-midi: that is an output port. Only input ports receive midi.');
+			}
+			if (!isPortOpen(id.getTypedValue())) {
+				return constructFatalError(
+						'wait-for-midi: that midi port is not open. Pass it to open-midi-port first.');
 			}
 			let dv = constructDeferredValue();
 			dv.setAutoreset(true);

--- a/server/src/builtins/syscalls.js
+++ b/server/src/builtins/syscalls.js
@@ -28,7 +28,8 @@ import { RenderNode } from '../rendernode.js'
 import { systemState } from '../systemstate.js'
 import { rootManager } from '../rootmanager.js'
 import { experiments, getExperimentsAsString, getSettings, setSettingValue, hasSettingName } from '../globalappflags.js'
-import { UNBOUND } from '../environment.js'
+import { UNBOUND, BINDINGS } from '../environment.js'
+import { convertTimeToSamples, getSampleRate } from '../wavetablefunctions.js'
 import { webFontManager } from '../webfonts.js'
 import {
 	RENDER_MODE_NORM,
@@ -38,6 +39,24 @@ import {
 /**
  * Creates all syscall builtins.
  */
+// running `do every` loops, so the stop button can end them
+const runningLoops = {};
+let nextLoopId = 1;
+
+function stopAllLoops() {
+	for (let id in runningLoops) {
+		window.clearTimeout(runningLoops[id]);
+		delete runningLoops[id];
+	}
+}
+
+function anyLoopsRunning() {
+	for (let id in runningLoops) {
+		return true;
+	}
+	return false;
+}
+
 function createSyscalls() {
 
 	Builtin.createBuiltin(
@@ -108,6 +127,50 @@ function createSyscalls() {
 			return constructNil();
 		},
 		'Disconnects the event funnel (used to disable IDE features).'
+	);
+
+
+	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
+
+	Builtin.createBuiltin(
+		'do every',
+		[ 'f&', 'interval' ],
+		function $doEvery(env, executionEnvironment) {
+			let f = env.lb('f');
+			let interval = env.lb('interval');
+			let ms = (convertTimeToSamples(interval) / getSampleRate()) * 1000;
+			if (!(ms > 0)) {
+				return constructFatalError('do every: interval must be more than zero. Sorry!');
+			}
+
+			let id = nextLoopId++;
+			let seq = 0;
+			let expected = performance.now() + ms;
+
+			function tick() {
+				if (!runningLoops[id]) return;
+				let cmd = systemState.getSCF().makeCommandWithClosureOneArg(f, constructInteger(seq));
+				let r = systemState.getSCF().sEval2(cmd, BINDINGS, 'do every');
+				seq++;
+				if (Utils.isFatalError(r)) {
+					delete runningLoops[id];
+					return;
+				}
+				// Correcting against a running total rather than the last wake
+				// up, so lateness does not accumulate. If more than a whole
+				// interval was missed the skipped ones are dropped rather than
+				// fired in a burst to catch up.
+				let now = performance.now();
+				expected += ms;
+				if (expected < now) {
+					expected += Math.ceil((now - expected) / ms) * ms;
+				}
+				runningLoops[id] = window.setTimeout(tick, expected - now);
+			}
+			runningLoops[id] = window.setTimeout(tick, ms);
+			return f;
+		},
+		'Runs |f every |interval, forever. |interval takes a timebase tag like any other length. |f is passed the number of times it has run, starting at zero, which it can take as an argument or ignore. Stops if |f returns a fatal error, or when the stop button is pressed.'
 	);
 
 	Builtin.createBuiltin(
@@ -260,5 +323,5 @@ function createSyscalls() {
 	);
 }
 
-export { createSyscalls }
+export { createSyscalls, stopAllLoops, anyLoopsRunning }
 

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -148,13 +148,19 @@ function createWavetableBuiltins() {
   Builtin.createBuiltin(
     "start-recording",
     ["_wt_", "channel#?"],
-    function $startRecording(env, executionEnvironment) {
+    function $startRecording(env, executionEnvironment, commandTags) {
       let wt = env.lb("wt");
       let channel = env.lb("channel");
-      startRecordingAudio(wt, channel == UNBOUND ? 0 : channel.getTypedValue());
+      let unlimited = false;
+      for (let i = 0; commandTags && i < commandTags.length; i++) {
+        if (commandTags[i].getTagString() == "unlimited") {
+          unlimited = true;
+        }
+      }
+      startRecordingAudio(wt, channel == UNBOUND ? 0 : channel.getTypedValue(), unlimited);
       return wt;
     },
-    "Tells |wt to start recording from |channel of the audio input, or the first channel if |channel is not given. A wavetable holds one channel, so a stereo input is recorded one side at a time."
+    "Tells |wt to start recording from |channel of the audio input, or the first channel if |channel is not given. A wavetable holds one channel, so a stereo input is recorded one side at a time. Recording stops after 30 seconds unless this command is tagged `unlimited`."
   );
 
   Builtin.createBuiltin(

--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { isAnySoundPlaying, stopAllSound } from '../webaudio.js';
 import { anyMidiNotesSounding, midiPanic } from '../midifunctions.js';
+import { stopAllLoops, anyLoopsRunning } from '../builtins/syscalls.js';
 import { hasPendingSave } from '../autosave.js';
 
 // Neither playback nor the save debounce announces itself, so poll. Cheap --
@@ -15,7 +16,7 @@ const StatusNav = () => {
         const id = setInterval(() => {
             // a midi note left sounding is the same kind of problem as audio
             // still running, and more urgent -- nothing stops it on its own
-            setPlaying(isAnySoundPlaying() || anyMidiNotesSounding());
+            setPlaying(isAnySoundPlaying() || anyMidiNotesSounding() || anyLoopsRunning());
             setUnsaved(hasPendingSave());
         }, POLL_MS);
         return () => clearInterval(id);
@@ -25,8 +26,8 @@ const StatusNav = () => {
         <div className="statusnav">
             {unsaved && <div className="unsaveddot" title="not saved yet"></div>}
             {playing &&
-                <div className="statusnavitem stopbutton" title="stop all sound and midi notes"
-                     onClick={() => { stopAllSound(); midiPanic(); setPlaying(false); }}>
+                <div className="statusnavitem stopbutton" title="stop everything"
+                     onClick={() => { stopAllSound(); midiPanic(); stopAllLoops(); setPlaying(false); }}>
                     {/* currentColor so the icon follows the theme token on the parent */}
                     <svg viewBox="0 0 8 9" width="8" height="9" aria-hidden="true">
                         <rect x="0" y="0" width="3" height="9" fill="currentColor"/>

--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'preact/hooks';
 import { isAnySoundPlaying, stopAllSound } from '../webaudio.js';
+import { anyMidiNotesSounding, midiPanic } from '../midifunctions.js';
 import { hasPendingSave } from '../autosave.js';
 
 // Neither playback nor the save debounce announces itself, so poll. Cheap --
@@ -12,7 +13,9 @@ const StatusNav = () => {
 
     useEffect(() => {
         const id = setInterval(() => {
-            setPlaying(isAnySoundPlaying());
+            // a midi note left sounding is the same kind of problem as audio
+            // still running, and more urgent -- nothing stops it on its own
+            setPlaying(isAnySoundPlaying() || anyMidiNotesSounding());
             setUnsaved(hasPendingSave());
         }, POLL_MS);
         return () => clearInterval(id);
@@ -22,8 +25,8 @@ const StatusNav = () => {
         <div className="statusnav">
             {unsaved && <div className="unsaveddot" title="not saved yet"></div>}
             {playing &&
-                <div className="statusnavitem stopbutton" title="stop all sound"
-                     onClick={() => { stopAllSound(); setPlaying(false); }}>
+                <div className="statusnavitem stopbutton" title="stop all sound and midi notes"
+                     onClick={() => { stopAllSound(); midiPanic(); setPlaying(false); }}>
                     {/* currentColor so the icon follows the theme token on the parent */}
                     <svg viewBox="0 0 8 9" width="8" height="9" aria-hidden="true">
                         <rect x="0" y="0" width="3" height="9" fill="currentColor"/>

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -70,6 +70,7 @@ function addMidiListener(id, f) {
 
 function setupFirstInputListener(id, f) {
 	inputListeners[id] = [ f ];
+	if (!midi) return;
 	for (let entry of midi.inputs) {
 		let input = entry[1];
 		if (id == input.id) {
@@ -146,6 +147,18 @@ want the note and should get it.
 */
 const MIDI_NOTE_GAP_MS = 5;
 
+/*
+Ports opened with open-midi-port in this session.
+
+Opening is required before sending to a port or listening to one, always --
+not only when it turns out to be necessary. It is necessary after a refresh,
+because a port org is a value like any other and comes back with the document
+while requestMIDIAccess has not been called in the new session. Making it
+required only then would mean the same code working or not depending on how the
+session started, which is not a thing anyone should have to reason about.
+*/
+const openedPorts = {};
+
 // (port, channel, note) currently sounding, so they can be turned off again
 const soundingNotes = {};
 
@@ -158,21 +171,22 @@ Ports are named by an id that came from list-midi-ports. The device behind one
 can be unplugged between listing it and sending to it, in which case the lookup
 returns nothing and sending would fail somewhere less helpful.
 */
+function isPortOpen(portId) {
+	return !!openedPorts[portId];
+}
+
 function midiOutputOrThrow(portId) {
-	if (!midi) {
-		throw constructFatalError('midi is not set up yet. Call list-midi-ports first.');
+	if (!midi || !openedPorts[portId]) {
+		throw constructFatalError(
+				'that midi port is not open. Pass it to open-midi-port first. A port is only '
+				+ 'its name and id until it is opened, and one remembered from a previous '
+				+ 'session is never open to begin with.');
 	}
 	let out = midi.outputs.get(portId);
 	if (!out) {
 		throw constructFatalError(
 				`no midi output with id ${portId}. It may have been unplugged -- `
 				+ `call list-midi-ports again to see what is there now.`);
-	}
-	// send() opens a closed port by itself, but that open is asynchronous, and
-	// it is not worth finding out the hard way whether the first message of a
-	// session survives it. Opening is idempotent.
-	if (out.connection == 'closed') {
-		out.open();
 	}
 	return out;
 }
@@ -261,6 +275,31 @@ function midiPanic() {
 	}
 }
 
+/*
+Reconnects one port that is already known by id.
+
+A port org is a value like any other, so it is saved with the document and
+comes back after a refresh -- with its name and id intact and nothing behind
+them, because requestMIDIAccess has not been called in the new session. This
+asks for access again and opens that one port, without listing everything.
+*/
+function openMidiPort(portId, incb) {
+	let cb = function() {
+		let port = midi.outputs.get(portId);
+		if (!port) {
+			port = midi.inputs.get(portId);
+		}
+		if (!port) {
+			incb(null);
+			return;
+		}
+		port.open();
+		openedPorts[portId] = true;
+		incb(describePort(port));
+	}
+	maybeSetupMidi(cb);
+}
+
 function getMidiPorts(incb) {
 	let cb = function() {
 		let r = [];
@@ -276,5 +315,5 @@ function getMidiPorts(incb) {
 }
 
 
-export { getMidiPorts, addMidiListener, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+export { getMidiPorts, openMidiPort, isPortOpen, addMidiListener, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
 		 sendMidiNoteWithDuration, anyMidiNotesSounding, midiPanic }

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -17,6 +17,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Tag } from './tag.js'
 import { constructOrg, convertJSMapToOrg } from './nex/org.js'
+import { constructFatalError } from './nex/eerror.js'
 
 
 var midi = null;
@@ -134,6 +135,126 @@ matching on manufacturer and name, which is a guess, so the names are handed
 over as they are and anything that wants to group can do it where the strings
 are visible.
 */
+/*
+Note offs for a note with a duration are scheduled a little early, so that in a
+sequence the off lands before the next note on rather than racing it. Five
+milliseconds is inaudible -- a note that short cannot be heard at all -- and is
+comfortably more than the wire takes to carry a three byte message.
+
+Only for beats. Someone working in seconds or hz has said exactly how long they
+want the note and should get it.
+*/
+const MIDI_NOTE_GAP_MS = 5;
+
+// (port, channel, note) currently sounding, so they can be turned off again
+const soundingNotes = {};
+
+function noteKey(portId, channel, note) {
+	return portId + ':' + channel + ':' + note;
+}
+
+/*
+Ports are named by an id that came from list-midi-ports. The device behind one
+can be unplugged between listing it and sending to it, in which case the lookup
+returns nothing and sending would fail somewhere less helpful.
+*/
+function midiOutputOrThrow(portId) {
+	if (!midi) {
+		throw constructFatalError('midi is not set up yet. Call list-midi-ports first.');
+	}
+	let out = midi.outputs.get(portId);
+	if (!out) {
+		throw constructFatalError(
+				`no midi output with id ${portId}. It may have been unplugged -- `
+				+ `call list-midi-ports again to see what is there now.`);
+	}
+	return out;
+}
+
+// channels are 1-16 here, as they are on every piece of hardware, and 0-15 on
+// the wire
+function statusByte(kind, channel) {
+	return kind | ((channel - 1) & 0x0F);
+}
+
+function sendMidiData(portId, bytes) {
+	midiOutputOrThrow(portId).send(bytes);
+}
+
+function sendMidiNoteOn(portId, channel, note, velocity) {
+	midiOutputOrThrow(portId).send([statusByte(0x90, channel), note, velocity]);
+	soundingNotes[noteKey(portId, channel, note)] = {
+		portId: portId, channel: channel, note: note
+	};
+}
+
+function sendMidiNoteOff(portId, channel, note, velocity) {
+	midiOutputOrThrow(portId).send([statusByte(0x80, channel), note, velocity]);
+	delete soundingNotes[noteKey(portId, channel, note)];
+}
+
+/*
+On now, off later. The off is handed to the browser with a timestamp rather
+than sent from a timer of ours, so its timing does not depend on the event
+queue, which is driven by setTimeout and is not steady enough to hold a
+sequence together.
+
+The timer alongside it only forgets the note; the message is already scheduled
+and will go whatever happens here.
+*/
+function sendMidiNoteWithDuration(portId, channel, note, velocity, durationMs, isBeats) {
+	let ms = durationMs;
+	if (isBeats) {
+		ms = ms - MIDI_NOTE_GAP_MS;
+	}
+	// never schedule the off before the on
+	if (ms < 1) ms = 1;
+
+	let out = midiOutputOrThrow(portId);
+	out.send([statusByte(0x90, channel), note, velocity]);
+	out.send([statusByte(0x80, channel), note, 0], performance.now() + ms);
+
+	let key = noteKey(portId, channel, note);
+	soundingNotes[key] = { portId: portId, channel: channel, note: note };
+	window.setTimeout(function() {
+		delete soundingNotes[key];
+	}, ms);
+}
+
+function anyMidiNotesSounding() {
+	for (let k in soundingNotes) {
+		return true;
+	}
+	return false;
+}
+
+/*
+Every note we know to be sounding, turned off, plus an all-notes-off on each
+channel touched as a backstop for anything we lost track of -- a note on sent
+as raw data, or one left over from before a reload.
+*/
+function midiPanic() {
+	if (!midi) return;
+	let channelsTouched = {};
+	for (let k in soundingNotes) {
+		let n = soundingNotes[k];
+		channelsTouched[n.portId + ':' + n.channel] = n;
+		let out = midi.outputs.get(n.portId);
+		if (out) {
+			out.send([statusByte(0x80, n.channel), n.note, 0]);
+		}
+		delete soundingNotes[k];
+	}
+	for (let k in channelsTouched) {
+		let n = channelsTouched[k];
+		let out = midi.outputs.get(n.portId);
+		// cc 123, all notes off
+		if (out) {
+			out.send([statusByte(0xB0, n.channel), 123, 0]);
+		}
+	}
+}
+
 function getMidiPorts(incb) {
 	let cb = function() {
 		let r = [];
@@ -149,4 +270,5 @@ function getMidiPorts(incb) {
 }
 
 
-export { getMidiPorts, addMidiListener }
+export { getMidiPorts, addMidiListener, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+		 sendMidiNoteWithDuration, anyMidiNotesSounding, midiPanic }

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -113,21 +113,35 @@ function respondToMidiMessage(id, msg) {
 	}
 }
 
-function getMidiDevices(incb) {
+function describePort(port) {
+	let m = {};
+	addToMap(m, port, 'id');
+	addToMap(m, port, 'manufacturer');
+	// already 'input' or 'output' -- MIDIPort.type in the spec
+	addToMap(m, port, 'type');
+	addToMap(m, port, 'name');
+	addToMap(m, port, 'version');
+	addToMap(m, port, 'state');
+	addToMap(m, port, 'connection');
+	return m;
+}
+
+/*
+Every port, both directions, in one list. Web midi has no notion of a device --
+a MIDIPort says nothing about which box it belongs to, and a bidirectional
+device appears as two separate ports, one in each map. Grouping them would mean
+matching on manufacturer and name, which is a guess, so the names are handed
+over as they are and anything that wants to group can do it where the strings
+are visible.
+*/
+function getMidiPorts(incb) {
 	let cb = function() {
 		let r = [];
 		for (let entry of midi.inputs) {
-			var input = entry[1];
-			let m = {};
-			addToMap(m, input, 'id');
-			addToMap(m, input, 'manufacturer');
-			addToMap(m, input, 'name');
-			addToMap(m, input, 'type');
-			addToMap(m, input, 'version');
-			addToMap(m, input, 'state');
-			addToMap(m, input, 'connection');
-
-			r.push(m);
+			r.push(describePort(entry[1]));
+		}
+		for (let entry of midi.outputs) {
+			r.push(describePort(entry[1]));
 		}
 		incb(r);
 	}
@@ -135,4 +149,4 @@ function getMidiDevices(incb) {
 }
 
 
-export { getMidiDevices, addMidiListener }
+export { getMidiPorts, addMidiListener }

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -128,35 +128,15 @@ function describePort(port) {
 	return m;
 }
 
-/*
-Every port, both directions, in one list. Web midi has no notion of a device --
-a MIDIPort says nothing about which box it belongs to, and a bidirectional
-device appears as two separate ports, one in each map. Grouping them would mean
-matching on manufacturer and name, which is a guess, so the names are handed
-over as they are and anything that wants to group can do it where the strings
-are visible.
-*/
-/*
-Note offs for a note with a duration are scheduled a little early, so that in a
-sequence the off lands before the next note on rather than racing it. Five
-milliseconds is inaudible -- a note that short cannot be heard at all -- and is
-comfortably more than the wire takes to carry a three byte message.
-
-Only for beats. Someone working in seconds or hz has said exactly how long they
-want the note and should get it.
-*/
+// Both directions in one list. Web midi has no notion of a device -- a
+// bidirectional box appears as two ports with nothing tying them together --
+// so grouping is left to whoever can see the names.
+// Beat durations are shortened by this so a note off lands before the next note
+// on. Inaudible. Other timebases are left alone -- that length was asked for.
 const MIDI_NOTE_GAP_MS = 5;
 
-/*
-Ports opened with open-midi-port in this session.
-
-Opening is required before sending to a port or listening to one, always --
-not only when it turns out to be necessary. It is necessary after a refresh,
-because a port org is a value like any other and comes back with the document
-while requestMIDIAccess has not been called in the new session. Making it
-required only then would mean the same code working or not depending on how the
-session started, which is not a thing anyone should have to reason about.
-*/
+// Opening is required always, not just after a refresh -- otherwise the same
+// code works or doesn't depending on how the session started.
 const openedPorts = {};
 
 // (port, channel, note) currently sounding, so they can be turned off again
@@ -166,27 +146,17 @@ function noteKey(portId, channel, note) {
 	return portId + ':' + channel + ':' + note;
 }
 
-/*
-Ports are named by an id that came from list-midi-ports. The device behind one
-can be unplugged between listing it and sending to it, in which case the lookup
-returns nothing and sending would fail somewhere less helpful.
-*/
 function isPortOpen(portId) {
 	return !!openedPorts[portId];
 }
 
 function midiOutputOrThrow(portId) {
 	if (!midi || !openedPorts[portId]) {
-		throw constructFatalError(
-				'that midi port is not open. Pass it to open-midi-port first. A port is only '
-				+ 'its name and id until it is opened, and one remembered from a previous '
-				+ 'session is never open to begin with.');
+		throw constructFatalError('you must open the midi port first. Sorry!');
 	}
 	let out = midi.outputs.get(portId);
 	if (!out) {
-		throw constructFatalError(
-				`no midi output with id ${portId}. It may have been unplugged -- `
-				+ `call list-midi-ports again to see what is there now.`);
+		throw constructFatalError(`no midi output with id ${portId}. Sorry!`);
 	}
 	return out;
 }
@@ -213,15 +183,9 @@ function sendMidiNoteOff(portId, channel, note, velocity) {
 	delete soundingNotes[noteKey(portId, channel, note)];
 }
 
-/*
-On now, off later. The off is handed to the browser with a timestamp rather
-than sent from a timer of ours, so its timing does not depend on the event
-queue, which is driven by setTimeout and is not steady enough to hold a
-sequence together.
-
-The timer alongside it only forgets the note; the message is already scheduled
-and will go whatever happens here.
-*/
+// The off is scheduled by the browser, not by a timer of ours -- the event
+// queue is setTimeout-driven and too jittery to hold a sequence together. The
+// timer here only forgets the note; the message is already on its way.
 function sendMidiNoteWithDuration(portId, channel, note, velocity, durationMs, isBeats) {
 	let ms = durationMs;
 	if (isBeats) {
@@ -248,11 +212,8 @@ function anyMidiNotesSounding() {
 	return false;
 }
 
-/*
-Every note we know to be sounding, turned off, plus an all-notes-off on each
-channel touched as a backstop for anything we lost track of -- a note on sent
-as raw data, or one left over from before a reload.
-*/
+// All-notes-off per channel as well, for anything sent as raw data that we
+// never tracked.
 function midiPanic() {
 	if (!midi) return;
 	let channelsTouched = {};
@@ -275,14 +236,8 @@ function midiPanic() {
 	}
 }
 
-/*
-Reconnects one port that is already known by id.
-
-A port org is a value like any other, so it is saved with the document and
-comes back after a refresh -- with its name and id intact and nothing behind
-them, because requestMIDIAccess has not been called in the new session. This
-asks for access again and opens that one port, without listing everything.
-*/
+// A port org is saved with the document, so after a refresh it comes back as
+// just a name and an id. This asks for access again and opens that one port.
 function openMidiPort(portId, incb) {
 	let cb = function() {
 		let port = midi.outputs.get(portId);

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -168,6 +168,12 @@ function midiOutputOrThrow(portId) {
 				`no midi output with id ${portId}. It may have been unplugged -- `
 				+ `call list-midi-ports again to see what is there now.`);
 	}
+	// send() opens a closed port by itself, but that open is asynchronous, and
+	// it is not worth finding out the hard way whether the first message of a
+	// session survives it. Opening is idempotent.
+	if (out.connection == 'closed') {
+		out.open();
+	}
 	return out;
 }
 

--- a/server/src/wavetablefunctions.js
+++ b/server/src/wavetablefunctions.js
@@ -83,10 +83,16 @@ function getReferenceFrequency() {
 }
 
 
+/*
+Every tag is checked, not just the first. A value can carry more than one -- a
+midi note's duration is tagged `duration` as well as with its timebase -- and
+which came first should not decide whether the timebase is seen. Anything with
+a single tag behaves exactly as before.
+*/
 function nexToTimebase(input) {
 	let type = DEFAULT_TIMEBASE;
-	if (input.numTags() > 0) {
-		let t = input.getTag(0).getTagString();
+	for (let i = 0; i < input.numTags(); i++) {
+		let t = input.getTag(i).getTagString();
 		if (t == 'note' || t == 'nn') {
 			type = 'NOTE';
 		} else if (t == 'seconds' || t == 'second' || t == 'secs' || t == 'sec') {
@@ -97,7 +103,10 @@ function nexToTimebase(input) {
 			type = 'BEATS';
 		} else if (t == 'samples' || t == 'samps' || t == 'samp') {
 			type = 'SAMPLES';
+		} else {
+			continue;
 		}
+		break;
 	}
 	return type;
 }

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -39,6 +39,10 @@ let auditioningPlayer = null;
 
 let mediaRecorder = null;
 
+// A guardrail, not a real limit -- so a first recording cannot fill the disk
+// before anyone knows how to stop it. The `unlimited` tag lifts it.
+const RECORDING_LIMIT_MS = 30000;
+
 class AuditionPlayer {
 	// sustained means the sound keeps going after the key comes back up. Holding
 	// enter to audition is momentary; toggling playback with space is not.
@@ -169,7 +173,7 @@ function stopRecordingAudio(wt) {
 	wt.stopRecording();
 }
 
-function startRecordingAudio(wt, channel) {
+function startRecordingAudio(wt, channel, unlimited) {
 	maybeCreateAudioContext();	
 	if (!channel) channel = 0;
 	if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
@@ -216,12 +220,20 @@ function startRecordingAudio(wt, channel) {
 						+ (st.channelCount ? st.channelCount : '?') + ' channel(s) at '
 						+ (st.sampleRate ? st.sampleRate : '?') + 'Hz');
 			}
-			mediaRecorder.start(500);
-			window.setTimeout(function() {
-				if (wt.isRecording()) {
-					stopRecordingAudio(wt);
-				}
-			}, 30000)
+			// No timeslice: one dataavailable, at stop, with the whole take.
+			// Chunking made ondataavailable fire twice a second and each one
+			// decoded everything recorded so far, so a take got quadratically
+			// more expensive the longer it ran.
+			mediaRecorder.start();
+			if (!unlimited) {
+				window.setTimeout(function() {
+					if (wt.isRecording()) {
+						stopRecordingAudio(wt);
+						console.log('vodka: stopped at the 30 second limit. Tag start-recording '
+								+ 'with `unlimited` to record for longer.');
+					}
+				}, RECORDING_LIMIT_MS)
+			}
 		}).catch(function(err) {
 			console.log('couldnt open audio stream');
 		})

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -200,10 +200,7 @@ function startRecordingAudio(wt, channel) {
 						// A wavetable holds one channel, so a stereo input is
 						// recorded one side at a time.
 						if (channel >= buffer.numberOfChannels) {
-							throw constructFatalError(
-									`cannot record channel ${channel}: this input has `
-									+ `${buffer.numberOfChannels} channel`
-									+ `${buffer.numberOfChannels == 1 ? '' : 's'}.`);
+							throw constructFatalError(`no input channel ${channel}. Sorry!`);
 						}
 						wt.setRecordedData(buffer.getChannelData(channel));
 					}, function(err) {
@@ -272,10 +269,7 @@ function checkChannelExists(channel) {
 	let n = channelMergerNode.numberOfInputs;
 	if (!Number.isInteger(channel) || channel < 0 || channel >= n) {
 		throw constructFatalError(
-				`there is no channel ${channel}. The current audio device has ${n} output `
-				+ `channel${n == 1 ? '' : 's'}, so channels 0 through ${n - 1} can be played. `
-				+ `If you expected more, the browser may have opened a different device than `
-				+ `you meant -- it reads the channel count once, when the first sound plays.`);
+				`no channel ${channel}, this device has ${n} (0-${n - 1}). Sorry!`);
 	}
 }
 


### PR DESCRIPTION
[4/4] — stacked on #340. First step toward midi output; sending comes next once the shape is settled.

`list-midi-inputs` enumerated `midi.inputs` and nothing else, so there was no way to see an output port at all.

It is **`list-midi-ports`** now, returning both directions in one list. Each port already carries a `type` of `input` or `output` — that is `MIDIPort.type` in the spec, and the old code was already copying it — so nothing new was needed to tell them apart, and filtering by direction is an ordinary list operation.

## No device grouping, deliberately

Web MIDI has no notion of a device. A `MIDIPort` says nothing about which box it belongs to, and a bidirectional device appears as **two** separate ports, one in each map — so even a single ES-9 shows up twice. Grouping them would mean matching on `manufacturer` and a name prefix, which is a guess, and wrong for anything that does not name its ports predictably.

The names are handed over as they are. Anything that wants to group can do it in vodka, against strings that are visible.

## Also

- `wait-for-midi` refuses an output port now. With both directions listed it is easy to pass one by mistake, and listening to an output simply never fires — no error, nothing happens.
- `getMidiDevices` is `getMidiPorts`, since it never returned devices.

## Testing

Not run. On this machine `amidi -l` reports an ES-9 and an M-Track, each bidirectional with a single port, so `list-midi-ports` should show four entries — two inputs and two outputs.