### PR TITLE
[4/23] Midi output: list every port, send notes and raw data

### DIFF
--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,9 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiPorts } from '../midifunctions.js'
+import { getMidiPorts, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+		 sendMidiNoteWithDuration } from '../midifunctions.js'
+import { convertTimeToSamples, nexToTimebase, getSampleRate } from '../wavetablefunctions.js'
 import { constructOrg } from '../nex/org.js'; 
 import { constructDeferredValue } from '../nex/deferredvalue.js'; 
 import { constructFatalError, constructInfo, newTagOrThrowOOM } from '../nex/eerror.js'
@@ -61,6 +63,133 @@ function createMidiBuiltins() {
 		'Lists every midi port, in both directions. Each port is tagged |midiport, and its |type says whether it is an input or an output.'
 	);
 
+
+
+	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
+
+	/*
+	Shared by both send builtins: a port org came from list-midi-ports, so it
+	carries the id the browser knows it by, and says which direction it is.
+	*/
+	function portIdOrError(port, who) {
+		if (!port.hasTag(newTagOrThrowOOM('midiport', who + ', is midi port'))) {
+			return { error: constructFatalError(who + ': that is not a midi port. Use list-midi-ports.') };
+		}
+		let type = port.getChildTagged(newTagOrThrowOOM('type', who + ', type'));
+		if (type && type.getFullTypedValue() != 'output') {
+			return { error: constructFatalError(who + ': that is an input port. Midi is sent to outputs.') };
+		}
+		let id = port.getChildTagged(newTagOrThrowOOM('id', who + ', id'));
+		if (!id) {
+			return { error: constructFatalError(who + ': that midi port has no id.') };
+		}
+		return { id: id.getFullTypedValue() };
+	}
+
+	function taggedInt(org, name, who) {
+		let c = org.getChildTagged(newTagOrThrowOOM(name, who + ', ' + name));
+		return c ? c.getTypedValue() : null;
+	}
+
+	Builtin.createBuiltin(
+		'send-midi-data on',
+		[ 'data()', 'port()' ],
+		function $sendMidiData(env, executionEnvironment) {
+			let data = env.lb('data');
+			let port = portIdOrError(env.lb('port'), 'send-midi-data');
+			if (port.error) return port.error;
+
+			let bytes = [];
+			for (let i = 0; i < data.numChildren(); i++) {
+				let b = data.getChildAt(i).getTypedValue();
+				if (!Number.isInteger(b) || b < 0 || b > 255) {
+					return constructFatalError(
+							`send-midi-data: ${b} is not a byte. Midi data is whole numbers from 0 to 255.`);
+				}
+				bytes.push(b);
+			}
+			if (bytes.length == 0) {
+				return constructFatalError('send-midi-data: nothing to send.');
+			}
+			sendMidiData(port.id, bytes);
+			return data;
+		},
+		'Sends |data, an org of integers, to the midi port |port exactly as given. For anything the note builtin does not cover -- control changes, program changes, clock, sysex.'
+	);
+
+	/*
+	The tag on the integer says what kind of message this is, the same way a tag
+	on a number says what timebase it is in. `note` is a note with a duration,
+	which sends the note on now and schedules the note off; `note-on` and
+	`note-off` are the halves on their own, for an instrument where something
+	else decides when the note ends.
+
+	Deliberately no converting between a note off and a note on at velocity
+	zero. Devices differ, and note off velocity means release velocity on some
+	of them, so the two are not interchangeable. Writing `note-on` with a
+	velocity of 0 gives the second form if that is what a device wants.
+	*/
+	Builtin.createBuiltin(
+		'send-midi-note on',
+		[ 'note()', 'port()' ],
+		function $sendMidiNote(env, executionEnvironment) {
+			let n = env.lb('note');
+			let port = portIdOrError(env.lb('port'), 'send-midi-note');
+			if (port.error) return port.error;
+
+			let kind = null;
+			let notenum = null;
+			for (let k of ['note', 'note-on', 'note-off']) {
+				let v = taggedInt(n, k, 'send-midi-note');
+				if (v !== null) {
+					kind = k;
+					notenum = v;
+					break;
+				}
+			}
+			if (kind == null) {
+				return constructFatalError(
+						'send-midi-note: needs an integer tagged note, note-on or note-off.');
+			}
+			if (notenum < 0 || notenum > 127) {
+				return constructFatalError(
+						`send-midi-note: ${notenum} is not a midi note. Notes run from 0 to 127.`);
+			}
+
+			let velocity = taggedInt(n, 'velocity', 'send-midi-note');
+			if (velocity == null) velocity = 127;
+			if (velocity < 0 || velocity > 127) {
+				return constructFatalError(
+						`send-midi-note: velocity ${velocity} is out of range. Velocity runs from 0 to 127.`);
+			}
+
+			// 1-16, the way hardware shows them
+			let channel = taggedInt(n, 'channel', 'send-midi-note');
+			if (channel == null) channel = 1;
+			if (channel < 1 || channel > 16) {
+				return constructFatalError(
+						`send-midi-note: there is no channel ${channel}. Midi channels run from 1 to 16.`);
+			}
+
+			if (kind == 'note-on') {
+				sendMidiNoteOn(port.id, channel, notenum, velocity);
+			} else if (kind == 'note-off') {
+				sendMidiNoteOff(port.id, channel, notenum, velocity);
+			} else {
+				let dur = n.getChildTagged(newTagOrThrowOOM('duration', 'send-midi-note, duration'));
+				if (!dur) {
+					return constructFatalError(
+							'send-midi-note: a note tagged `note` needs a duration. Tag one with note-on '
+							+ 'and send a note-off yourself if you do not know how long it lasts.');
+				}
+				let timebase = nexToTimebase(dur);
+				let ms = (convertTimeToSamples(dur, timebase) / getSampleRate()) * 1000;
+				sendMidiNoteWithDuration(port.id, channel, notenum, velocity, ms, timebase == 'BEATS');
+			}
+			return n;
+		},
+		'Sends a midi note to the port |port. |note is an org holding an integer tagged note, note-on or note-off. A note tagged |note also needs a float tagged duration, which takes a timebase tag like any other length. Velocity defaults to 127 and channel to 1.'
+	);
 
 	Builtin.createBuiltin(
 		'wait-for-midi',

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiDevices } from '../midifunctions.js'
+import { getMidiPorts } from '../midifunctions.js'
 import { constructOrg } from '../nex/org.js'; 
 import { constructDeferredValue } from '../nex/deferredvalue.js'; 
 import { constructFatalError, constructInfo, newTagOrThrowOOM } from '../nex/eerror.js'
@@ -30,32 +30,32 @@ import {
 
 function createMidiBuiltins() {
 	Builtin.createBuiltin(
-		'list-midi-inputs',
+		'list-midi-ports',
 		[ ],
 		function $listMidiInputs(env, executionEnvironment) {
 			let dv = constructDeferredValue();
 			dv.set(new GenericActivationFunctionGenerator(
-				'list-midi-inputs', 
+				'list-midi-ports', 
 				function(callback, exp) {
-					getMidiDevices(function(devs) {
+					getMidiPorts(function(devs) {
 						// devices will just be a string
 						// convert to nice estrings
 						let r = constructOrg();
 						for (let i = 0; i < devs.length ; i++) {
 							let org = convertJSMapToOrg(devs[i]);
 							org.setHorizontal();
-							org.addTag(newTagOrThrowOOM('midiport', 'list midi imputs builtin'));
+							org.addTag(newTagOrThrowOOM('midiport', 'list midi ports builtin'));
 							r.appendChild(org);
 						}
 						callback(r);
 					})
 				}
 			));
-			let waitmessage = constructInfo(`listing midi inputs`);
+			let waitmessage = constructInfo(`listing midi ports`);
 			dv.appendChild(waitmessage)
 			return dv;
 		},
-		'Lists midi inputs.'
+		'Lists every midi port, in both directions. Each port is tagged |midiport, and its |type says whether it is an input or an output.'
 	);
 
 
@@ -68,6 +68,13 @@ function createMidiBuiltins() {
 			let id = midiport.getChildTagged(newTagOrThrowOOM('id', 'wait for midi builtin, id'));
 			if (!ismidiport || !id) {
 				return constructFatalError('wait-for-midi: must pass in a midiport object with a valid ID');
+			}
+			// now that both directions are listed, an output can be passed here
+			// by mistake, and listening to one just never fires
+			let type = midiport.getChildTagged(newTagOrThrowOOM('type', 'wait for midi builtin, type'));
+			if (type && type.getFullTypedValue() != 'input') {
+				return constructFatalError(
+						'wait-for-midi: that is an output port. Only input ports receive midi.');
 			}
 			let dv = constructDeferredValue();
 			dv.setAutoreset(true);

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -53,6 +53,9 @@ function createMidiBuiltins() {
 			));
 			let waitmessage = constructInfo(`listing midi ports`);
 			dv.appendChild(waitmessage)
+			// without this the activation function never runs: the deferred sits
+			// showing its wait message forever, never having asked for anything
+			dv.activate();
 			return dv;
 		},
 		'Lists every midi port, in both directions. Each port is tagged |midiport, and its |type says whether it is an input or an output.'

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiPorts, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+import { getMidiPorts, openMidiPort, isPortOpen, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
 		 sendMidiNoteWithDuration } from '../midifunctions.js'
 import { convertTimeToSamples, nexToTimebase, getSampleRate } from '../wavetablefunctions.js'
 import { constructOrg } from '../nex/org.js'; 
@@ -90,6 +90,44 @@ function createMidiBuiltins() {
 		let c = org.getChildTagged(newTagOrThrowOOM(name, who + ', ' + name));
 		return c ? c.getTypedValue() : null;
 	}
+
+	Builtin.createBuiltin(
+		'open-midi-port',
+		[ 'port()' ],
+		function $openMidiPort(env, executionEnvironment) {
+			let port = env.lb('port');
+			let id = port.getChildTagged(newTagOrThrowOOM('id', 'open midi port, id'));
+			if (!port.hasTag(newTagOrThrowOOM('midiport', 'open midi port, is midi port')) || !id) {
+				return constructFatalError('open-midi-port: must pass in a midiport object with a valid ID');
+			}
+			let idstr = id.getFullTypedValue();
+
+			let dv = constructDeferredValue();
+			dv.set(new GenericActivationFunctionGenerator(
+				'open-midi-port',
+				function(callback, exp) {
+					openMidiPort(idstr, function(desc) {
+						if (!desc) {
+							callback(constructFatalError(
+									`open-midi-port: there is no port with id ${idstr} any more. `
+									+ `It may have been unplugged -- call list-midi-ports to see `
+									+ `what is there now.`));
+							return;
+						}
+						let org = convertJSMapToOrg(desc);
+						org.setHorizontal();
+						org.addTag(newTagOrThrowOOM('midiport', 'open midi port builtin'));
+						callback(org);
+					})
+				}
+			));
+			let waitmessage = constructInfo(`opening midi port`);
+			dv.appendChild(waitmessage)
+			dv.activate();
+			return dv;
+		},
+		'Reconnects the midi port |port and returns it with its state as it is now. A port remembered from a previous session is only its name and id until this is called; list-midi-ports does the same thing for every port at once.'
+	);
 
 	Builtin.createBuiltin(
 		'send-midi-data on',
@@ -207,6 +245,10 @@ function createMidiBuiltins() {
 			if (type && type.getFullTypedValue() != 'input') {
 				return constructFatalError(
 						'wait-for-midi: that is an output port. Only input ports receive midi.');
+			}
+			if (!isPortOpen(id.getTypedValue())) {
+				return constructFatalError(
+						'wait-for-midi: that midi port is not open. Pass it to open-midi-port first.');
 			}
 			let dv = constructDeferredValue();
 			dv.setAutoreset(true);

--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'preact/hooks';
 import { isAnySoundPlaying, stopAllSound } from '../webaudio.js';
+import { anyMidiNotesSounding, midiPanic } from '../midifunctions.js';
 import { hasPendingSave } from '../autosave.js';
 
 // Neither playback nor the save debounce announces itself, so poll. Cheap --
@@ -12,7 +13,9 @@ const StatusNav = () => {
 
     useEffect(() => {
         const id = setInterval(() => {
-            setPlaying(isAnySoundPlaying());
+            // a midi note left sounding is the same kind of problem as audio
+            // still running, and more urgent -- nothing stops it on its own
+            setPlaying(isAnySoundPlaying() || anyMidiNotesSounding());
             setUnsaved(hasPendingSave());
         }, POLL_MS);
         return () => clearInterval(id);
@@ -22,8 +25,8 @@ const StatusNav = () => {
         <div className="statusnav">
             {unsaved && <div className="unsaveddot" title="not saved yet"></div>}
             {playing &&
-                <div className="statusnavitem stopbutton" title="stop all sound"
-                     onClick={() => { stopAllSound(); setPlaying(false); }}>
+                <div className="statusnavitem stopbutton" title="stop all sound and midi notes"
+                     onClick={() => { stopAllSound(); midiPanic(); setPlaying(false); }}>
                     {/* currentColor so the icon follows the theme token on the parent */}
                     <svg viewBox="0 0 8 9" width="8" height="9" aria-hidden="true">
                         <rect x="0" y="0" width="3" height="9" fill="currentColor"/>

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -70,6 +70,7 @@ function addMidiListener(id, f) {
 
 function setupFirstInputListener(id, f) {
 	inputListeners[id] = [ f ];
+	if (!midi) return;
 	for (let entry of midi.inputs) {
 		let input = entry[1];
 		if (id == input.id) {
@@ -146,6 +147,18 @@ want the note and should get it.
 */
 const MIDI_NOTE_GAP_MS = 5;
 
+/*
+Ports opened with open-midi-port in this session.
+
+Opening is required before sending to a port or listening to one, always --
+not only when it turns out to be necessary. It is necessary after a refresh,
+because a port org is a value like any other and comes back with the document
+while requestMIDIAccess has not been called in the new session. Making it
+required only then would mean the same code working or not depending on how the
+session started, which is not a thing anyone should have to reason about.
+*/
+const openedPorts = {};
+
 // (port, channel, note) currently sounding, so they can be turned off again
 const soundingNotes = {};
 
@@ -158,21 +171,22 @@ Ports are named by an id that came from list-midi-ports. The device behind one
 can be unplugged between listing it and sending to it, in which case the lookup
 returns nothing and sending would fail somewhere less helpful.
 */
+function isPortOpen(portId) {
+	return !!openedPorts[portId];
+}
+
 function midiOutputOrThrow(portId) {
-	if (!midi) {
-		throw constructFatalError('midi is not set up yet. Call list-midi-ports first.');
+	if (!midi || !openedPorts[portId]) {
+		throw constructFatalError(
+				'that midi port is not open. Pass it to open-midi-port first. A port is only '
+				+ 'its name and id until it is opened, and one remembered from a previous '
+				+ 'session is never open to begin with.');
 	}
 	let out = midi.outputs.get(portId);
 	if (!out) {
 		throw constructFatalError(
 				`no midi output with id ${portId}. It may have been unplugged -- `
 				+ `call list-midi-ports again to see what is there now.`);
-	}
-	// send() opens a closed port by itself, but that open is asynchronous, and
-	// it is not worth finding out the hard way whether the first message of a
-	// session survives it. Opening is idempotent.
-	if (out.connection == 'closed') {
-		out.open();
 	}
 	return out;
 }
@@ -261,6 +275,31 @@ function midiPanic() {
 	}
 }
 
+/*
+Reconnects one port that is already known by id.
+
+A port org is a value like any other, so it is saved with the document and
+comes back after a refresh -- with its name and id intact and nothing behind
+them, because requestMIDIAccess has not been called in the new session. This
+asks for access again and opens that one port, without listing everything.
+*/
+function openMidiPort(portId, incb) {
+	let cb = function() {
+		let port = midi.outputs.get(portId);
+		if (!port) {
+			port = midi.inputs.get(portId);
+		}
+		if (!port) {
+			incb(null);
+			return;
+		}
+		port.open();
+		openedPorts[portId] = true;
+		incb(describePort(port));
+	}
+	maybeSetupMidi(cb);
+}
+
 function getMidiPorts(incb) {
 	let cb = function() {
 		let r = [];
@@ -276,5 +315,5 @@ function getMidiPorts(incb) {
 }
 
 
-export { getMidiPorts, addMidiListener, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+export { getMidiPorts, openMidiPort, isPortOpen, addMidiListener, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
 		 sendMidiNoteWithDuration, anyMidiNotesSounding, midiPanic }

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -17,6 +17,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Tag } from './tag.js'
 import { constructOrg, convertJSMapToOrg } from './nex/org.js'
+import { constructFatalError } from './nex/eerror.js'
 
 
 var midi = null;
@@ -134,6 +135,126 @@ matching on manufacturer and name, which is a guess, so the names are handed
 over as they are and anything that wants to group can do it where the strings
 are visible.
 */
+/*
+Note offs for a note with a duration are scheduled a little early, so that in a
+sequence the off lands before the next note on rather than racing it. Five
+milliseconds is inaudible -- a note that short cannot be heard at all -- and is
+comfortably more than the wire takes to carry a three byte message.
+
+Only for beats. Someone working in seconds or hz has said exactly how long they
+want the note and should get it.
+*/
+const MIDI_NOTE_GAP_MS = 5;
+
+// (port, channel, note) currently sounding, so they can be turned off again
+const soundingNotes = {};
+
+function noteKey(portId, channel, note) {
+	return portId + ':' + channel + ':' + note;
+}
+
+/*
+Ports are named by an id that came from list-midi-ports. The device behind one
+can be unplugged between listing it and sending to it, in which case the lookup
+returns nothing and sending would fail somewhere less helpful.
+*/
+function midiOutputOrThrow(portId) {
+	if (!midi) {
+		throw constructFatalError('midi is not set up yet. Call list-midi-ports first.');
+	}
+	let out = midi.outputs.get(portId);
+	if (!out) {
+		throw constructFatalError(
+				`no midi output with id ${portId}. It may have been unplugged -- `
+				+ `call list-midi-ports again to see what is there now.`);
+	}
+	return out;
+}
+
+// channels are 1-16 here, as they are on every piece of hardware, and 0-15 on
+// the wire
+function statusByte(kind, channel) {
+	return kind | ((channel - 1) & 0x0F);
+}
+
+function sendMidiData(portId, bytes) {
+	midiOutputOrThrow(portId).send(bytes);
+}
+
+function sendMidiNoteOn(portId, channel, note, velocity) {
+	midiOutputOrThrow(portId).send([statusByte(0x90, channel), note, velocity]);
+	soundingNotes[noteKey(portId, channel, note)] = {
+		portId: portId, channel: channel, note: note
+	};
+}
+
+function sendMidiNoteOff(portId, channel, note, velocity) {
+	midiOutputOrThrow(portId).send([statusByte(0x80, channel), note, velocity]);
+	delete soundingNotes[noteKey(portId, channel, note)];
+}
+
+/*
+On now, off later. The off is handed to the browser with a timestamp rather
+than sent from a timer of ours, so its timing does not depend on the event
+queue, which is driven by setTimeout and is not steady enough to hold a
+sequence together.
+
+The timer alongside it only forgets the note; the message is already scheduled
+and will go whatever happens here.
+*/
+function sendMidiNoteWithDuration(portId, channel, note, velocity, durationMs, isBeats) {
+	let ms = durationMs;
+	if (isBeats) {
+		ms = ms - MIDI_NOTE_GAP_MS;
+	}
+	// never schedule the off before the on
+	if (ms < 1) ms = 1;
+
+	let out = midiOutputOrThrow(portId);
+	out.send([statusByte(0x90, channel), note, velocity]);
+	out.send([statusByte(0x80, channel), note, 0], performance.now() + ms);
+
+	let key = noteKey(portId, channel, note);
+	soundingNotes[key] = { portId: portId, channel: channel, note: note };
+	window.setTimeout(function() {
+		delete soundingNotes[key];
+	}, ms);
+}
+
+function anyMidiNotesSounding() {
+	for (let k in soundingNotes) {
+		return true;
+	}
+	return false;
+}
+
+/*
+Every note we know to be sounding, turned off, plus an all-notes-off on each
+channel touched as a backstop for anything we lost track of -- a note on sent
+as raw data, or one left over from before a reload.
+*/
+function midiPanic() {
+	if (!midi) return;
+	let channelsTouched = {};
+	for (let k in soundingNotes) {
+		let n = soundingNotes[k];
+		channelsTouched[n.portId + ':' + n.channel] = n;
+		let out = midi.outputs.get(n.portId);
+		if (out) {
+			out.send([statusByte(0x80, n.channel), n.note, 0]);
+		}
+		delete soundingNotes[k];
+	}
+	for (let k in channelsTouched) {
+		let n = channelsTouched[k];
+		let out = midi.outputs.get(n.portId);
+		// cc 123, all notes off
+		if (out) {
+			out.send([statusByte(0xB0, n.channel), 123, 0]);
+		}
+	}
+}
+
 function getMidiPorts(incb) {
 	let cb = function() {
 		let r = [];
@@ -149,4 +270,5 @@ function getMidiPorts(incb) {
 }
 
 
-export { getMidiPorts, addMidiListener }
+export { getMidiPorts, addMidiListener, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+		 sendMidiNoteWithDuration, anyMidiNotesSounding, midiPanic }

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -113,21 +113,35 @@ function respondToMidiMessage(id, msg) {
 	}
 }
 
-function getMidiDevices(incb) {
+function describePort(port) {
+	let m = {};
+	addToMap(m, port, 'id');
+	addToMap(m, port, 'manufacturer');
+	// already 'input' or 'output' -- MIDIPort.type in the spec
+	addToMap(m, port, 'type');
+	addToMap(m, port, 'name');
+	addToMap(m, port, 'version');
+	addToMap(m, port, 'state');
+	addToMap(m, port, 'connection');
+	return m;
+}
+
+/*
+Every port, both directions, in one list. Web midi has no notion of a device --
+a MIDIPort says nothing about which box it belongs to, and a bidirectional
+device appears as two separate ports, one in each map. Grouping them would mean
+matching on manufacturer and name, which is a guess, so the names are handed
+over as they are and anything that wants to group can do it where the strings
+are visible.
+*/
+function getMidiPorts(incb) {
 	let cb = function() {
 		let r = [];
 		for (let entry of midi.inputs) {
-			var input = entry[1];
-			let m = {};
-			addToMap(m, input, 'id');
-			addToMap(m, input, 'manufacturer');
-			addToMap(m, input, 'name');
-			addToMap(m, input, 'type');
-			addToMap(m, input, 'version');
-			addToMap(m, input, 'state');
-			addToMap(m, input, 'connection');
-
-			r.push(m);
+			r.push(describePort(entry[1]));
+		}
+		for (let entry of midi.outputs) {
+			r.push(describePort(entry[1]));
 		}
 		incb(r);
 	}
@@ -135,4 +149,4 @@ function getMidiDevices(incb) {
 }
 
 
-export { getMidiDevices, addMidiListener }
+export { getMidiPorts, addMidiListener }

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -168,6 +168,12 @@ function midiOutputOrThrow(portId) {
 				`no midi output with id ${portId}. It may have been unplugged -- `
 				+ `call list-midi-ports again to see what is there now.`);
 	}
+	// send() opens a closed port by itself, but that open is asynchronous, and
+	// it is not worth finding out the hard way whether the first message of a
+	// session survives it. Opening is idempotent.
+	if (out.connection == 'closed') {
+		out.open();
+	}
 	return out;
 }
 

--- a/server/src/wavetablefunctions.js
+++ b/server/src/wavetablefunctions.js
@@ -83,10 +83,16 @@ function getReferenceFrequency() {
 }
 
 
+/*
+Every tag is checked, not just the first. A value can carry more than one -- a
+midi note's duration is tagged `duration` as well as with its timebase -- and
+which came first should not decide whether the timebase is seen. Anything with
+a single tag behaves exactly as before.
+*/
 function nexToTimebase(input) {
 	let type = DEFAULT_TIMEBASE;
-	if (input.numTags() > 0) {
-		let t = input.getTag(0).getTagString();
+	for (let i = 0; i < input.numTags(); i++) {
+		let t = input.getTag(i).getTagString();
 		if (t == 'note' || t == 'nn') {
 			type = 'NOTE';
 		} else if (t == 'seconds' || t == 'second' || t == 'secs' || t == 'sec') {
@@ -97,7 +103,10 @@ function nexToTimebase(input) {
 			type = 'BEATS';
 		} else if (t == 'samples' || t == 'samps' || t == 'samp') {
 			type = 'SAMPLES';
+		} else {
+			continue;
 		}
+		break;
 	}
 	return type;
 }


### PR DESCRIPTION
Stacked on #340. Was part of #341, which has been split.

Five commits that make the midi builtins usable for output. `list-midi-inputs` becomes `list-midi-ports` and returns both directions in one list, since each port already carries its `input`/`output` type — there was previously no way to see an output at all, let alone send to one. Ports are not grouped into devices, because web midi has no notion of a device and grouping would mean guessing from manufacturer and name strings. The listing deferred was also created and returned without ever being activated, so nothing ever asked the browser for the ports and it never resolved; that is fixed here. Then two builtins to send, `_send-midi-data @d on @port_` and `_send-midi-note @n on @port_`, where a tag on the integer says whether it is a `note` (note on now, note off scheduled), a `note-on`, or a `note-off`. Finally `open-midi-port`, now required before sending to or listening on a port, because a port org is saved with the document and comes back after a refresh with its name and id intact and nothing behind them.

Worth a reviewer's attention:

- `aacee27` adds an explicit open before send, and `9d66c83` then replaces it with the required `open-midi-port`. Both are kept deliberately.
- Requiring the open always, rather than only when it turns out to be necessary, is a deliberate call: otherwise the same code works or does not depending on how the session started, and the failure would only show up after a refresh.
- Channels are 1 to 16 in the language, the way hardware shows them, and 0 to 15 on the wire. Velocity defaults to 127, channel to 1.
- Nothing converts a note off into a note on at velocity zero. Devices differ, and note off velocity is release velocity on some of them. Write `note-on` with a velocity of 0 for that form.
- Durations in beats are shortened by five milliseconds so the note off lands before the next note on rather than racing it. Beats only — seconds and hz are taken literally.
- The note off is handed to the browser with a timestamp rather than fired from a timer of ours, so it does not depend on the event queue.
- `wait-for-midi` now refuses an output port, since listening to one never fires.
- Sounding notes are tracked, and the nav stop button now panics them: an explicit note off for everything known to be sounding, then an all-notes-off on each channel touched.
- `nexToTimebase` now checks every tag rather than only the first, since a duration carries `duration` as well as its timebase.
- Rename: `getMidiDevices` is now `getMidiPorts`, since it never returned devices.
