### PR TITLE
[5/23] Shorten the midi and audio channel errors

### DIFF
--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -67,21 +67,17 @@ function createMidiBuiltins() {
 
 	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
 
-	/*
-	Shared by both send builtins: a port org came from list-midi-ports, so it
-	carries the id the browser knows it by, and says which direction it is.
-	*/
 	function portIdOrError(port, who) {
 		if (!port.hasTag(newTagOrThrowOOM('midiport', who + ', is midi port'))) {
-			return { error: constructFatalError(who + ': that is not a midi port. Use list-midi-ports.') };
+			return { error: constructFatalError(who + ': not a midi port. Sorry!') };
 		}
 		let type = port.getChildTagged(newTagOrThrowOOM('type', who + ', type'));
 		if (type && type.getFullTypedValue() != 'output') {
-			return { error: constructFatalError(who + ': that is an input port. Midi is sent to outputs.') };
+			return { error: constructFatalError(who + ': that is an input port. Sorry!') };
 		}
 		let id = port.getChildTagged(newTagOrThrowOOM('id', who + ', id'));
 		if (!id) {
-			return { error: constructFatalError(who + ': that midi port has no id.') };
+			return { error: constructFatalError(who + ': midi port has no id. Sorry!') };
 		}
 		return { id: id.getFullTypedValue() };
 	}
@@ -109,9 +105,7 @@ function createMidiBuiltins() {
 					openMidiPort(idstr, function(desc) {
 						if (!desc) {
 							callback(constructFatalError(
-									`open-midi-port: there is no port with id ${idstr} any more. `
-									+ `It may have been unplugged -- call list-midi-ports to see `
-									+ `what is there now.`));
+									`open-midi-port: no port with id ${idstr}. Sorry!`));
 							return;
 						}
 						let org = convertJSMapToOrg(desc);
@@ -141,13 +135,12 @@ function createMidiBuiltins() {
 			for (let i = 0; i < data.numChildren(); i++) {
 				let b = data.getChildAt(i).getTypedValue();
 				if (!Number.isInteger(b) || b < 0 || b > 255) {
-					return constructFatalError(
-							`send-midi-data: ${b} is not a byte. Midi data is whole numbers from 0 to 255.`);
+					return constructFatalError(`send-midi-data: ${b} is not a byte (0-255). Sorry!`);
 				}
 				bytes.push(b);
 			}
 			if (bytes.length == 0) {
-				return constructFatalError('send-midi-data: nothing to send.');
+				return constructFatalError('send-midi-data: nothing to send. Sorry!');
 			}
 			sendMidiData(port.id, bytes);
 			return data;
@@ -155,18 +148,9 @@ function createMidiBuiltins() {
 		'Sends |data, an org of integers, to the midi port |port exactly as given. For anything the note builtin does not cover -- control changes, program changes, clock, sysex.'
 	);
 
-	/*
-	The tag on the integer says what kind of message this is, the same way a tag
-	on a number says what timebase it is in. `note` is a note with a duration,
-	which sends the note on now and schedules the note off; `note-on` and
-	`note-off` are the halves on their own, for an instrument where something
-	else decides when the note ends.
-
-	Deliberately no converting between a note off and a note on at velocity
-	zero. Devices differ, and note off velocity means release velocity on some
-	of them, so the two are not interchangeable. Writing `note-on` with a
-	velocity of 0 gives the second form if that is what a device wants.
-	*/
+	// The tag on the int picks the message, like a timebase tag picks a unit.
+	// No converting note-off to note-on-at-zero: note off velocity is release
+	// velocity on some devices, so they aren't interchangeable.
 	Builtin.createBuiltin(
 		'send-midi-note on',
 		[ 'note()', 'port()' ],
@@ -187,26 +171,23 @@ function createMidiBuiltins() {
 			}
 			if (kind == null) {
 				return constructFatalError(
-						'send-midi-note: needs an integer tagged note, note-on or note-off.');
+						'send-midi-note: needs an int tagged note, note-on or note-off. Sorry!');
 			}
 			if (notenum < 0 || notenum > 127) {
-				return constructFatalError(
-						`send-midi-note: ${notenum} is not a midi note. Notes run from 0 to 127.`);
+				return constructFatalError(`send-midi-note: ${notenum} is not a note (0-127). Sorry!`);
 			}
 
 			let velocity = taggedInt(n, 'velocity', 'send-midi-note');
 			if (velocity == null) velocity = 127;
 			if (velocity < 0 || velocity > 127) {
-				return constructFatalError(
-						`send-midi-note: velocity ${velocity} is out of range. Velocity runs from 0 to 127.`);
+				return constructFatalError(`send-midi-note: velocity ${velocity} is out of range (0-127). Sorry!`);
 			}
 
 			// 1-16, the way hardware shows them
 			let channel = taggedInt(n, 'channel', 'send-midi-note');
 			if (channel == null) channel = 1;
 			if (channel < 1 || channel > 16) {
-				return constructFatalError(
-						`send-midi-note: there is no channel ${channel}. Midi channels run from 1 to 16.`);
+				return constructFatalError(`send-midi-note: no channel ${channel} (1-16). Sorry!`);
 			}
 
 			if (kind == 'note-on') {
@@ -216,9 +197,7 @@ function createMidiBuiltins() {
 			} else {
 				let dur = n.getChildTagged(newTagOrThrowOOM('duration', 'send-midi-note, duration'));
 				if (!dur) {
-					return constructFatalError(
-							'send-midi-note: a note tagged `note` needs a duration. Tag one with note-on '
-							+ 'and send a note-off yourself if you do not know how long it lasts.');
+					return constructFatalError('send-midi-note: a note needs a duration. Sorry!');
 				}
 				let timebase = nexToTimebase(dur);
 				let ms = (convertTimeToSamples(dur, timebase) / getSampleRate()) * 1000;
@@ -243,12 +222,10 @@ function createMidiBuiltins() {
 			// by mistake, and listening to one just never fires
 			let type = midiport.getChildTagged(newTagOrThrowOOM('type', 'wait for midi builtin, type'));
 			if (type && type.getFullTypedValue() != 'input') {
-				return constructFatalError(
-						'wait-for-midi: that is an output port. Only input ports receive midi.');
+				return constructFatalError('wait-for-midi: that is an output port. Sorry!');
 			}
 			if (!isPortOpen(id.getTypedValue())) {
-				return constructFatalError(
-						'wait-for-midi: that midi port is not open. Pass it to open-midi-port first.');
+				return constructFatalError('wait-for-midi: you must open the midi port first. Sorry!');
 			}
 			let dv = constructDeferredValue();
 			dv.setAutoreset(true);

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -128,35 +128,15 @@ function describePort(port) {
 	return m;
 }
 
-/*
-Every port, both directions, in one list. Web midi has no notion of a device --
-a MIDIPort says nothing about which box it belongs to, and a bidirectional
-device appears as two separate ports, one in each map. Grouping them would mean
-matching on manufacturer and name, which is a guess, so the names are handed
-over as they are and anything that wants to group can do it where the strings
-are visible.
-*/
-/*
-Note offs for a note with a duration are scheduled a little early, so that in a
-sequence the off lands before the next note on rather than racing it. Five
-milliseconds is inaudible -- a note that short cannot be heard at all -- and is
-comfortably more than the wire takes to carry a three byte message.
-
-Only for beats. Someone working in seconds or hz has said exactly how long they
-want the note and should get it.
-*/
+// Both directions in one list. Web midi has no notion of a device -- a
+// bidirectional box appears as two ports with nothing tying them together --
+// so grouping is left to whoever can see the names.
+// Beat durations are shortened by this so a note off lands before the next note
+// on. Inaudible. Other timebases are left alone -- that length was asked for.
 const MIDI_NOTE_GAP_MS = 5;
 
-/*
-Ports opened with open-midi-port in this session.
-
-Opening is required before sending to a port or listening to one, always --
-not only when it turns out to be necessary. It is necessary after a refresh,
-because a port org is a value like any other and comes back with the document
-while requestMIDIAccess has not been called in the new session. Making it
-required only then would mean the same code working or not depending on how the
-session started, which is not a thing anyone should have to reason about.
-*/
+// Opening is required always, not just after a refresh -- otherwise the same
+// code works or doesn't depending on how the session started.
 const openedPorts = {};
 
 // (port, channel, note) currently sounding, so they can be turned off again
@@ -166,27 +146,17 @@ function noteKey(portId, channel, note) {
 	return portId + ':' + channel + ':' + note;
 }
 
-/*
-Ports are named by an id that came from list-midi-ports. The device behind one
-can be unplugged between listing it and sending to it, in which case the lookup
-returns nothing and sending would fail somewhere less helpful.
-*/
 function isPortOpen(portId) {
 	return !!openedPorts[portId];
 }
 
 function midiOutputOrThrow(portId) {
 	if (!midi || !openedPorts[portId]) {
-		throw constructFatalError(
-				'that midi port is not open. Pass it to open-midi-port first. A port is only '
-				+ 'its name and id until it is opened, and one remembered from a previous '
-				+ 'session is never open to begin with.');
+		throw constructFatalError('you must open the midi port first. Sorry!');
 	}
 	let out = midi.outputs.get(portId);
 	if (!out) {
-		throw constructFatalError(
-				`no midi output with id ${portId}. It may have been unplugged -- `
-				+ `call list-midi-ports again to see what is there now.`);
+		throw constructFatalError(`no midi output with id ${portId}. Sorry!`);
 	}
 	return out;
 }
@@ -213,15 +183,9 @@ function sendMidiNoteOff(portId, channel, note, velocity) {
 	delete soundingNotes[noteKey(portId, channel, note)];
 }
 
-/*
-On now, off later. The off is handed to the browser with a timestamp rather
-than sent from a timer of ours, so its timing does not depend on the event
-queue, which is driven by setTimeout and is not steady enough to hold a
-sequence together.
-
-The timer alongside it only forgets the note; the message is already scheduled
-and will go whatever happens here.
-*/
+// The off is scheduled by the browser, not by a timer of ours -- the event
+// queue is setTimeout-driven and too jittery to hold a sequence together. The
+// timer here only forgets the note; the message is already on its way.
 function sendMidiNoteWithDuration(portId, channel, note, velocity, durationMs, isBeats) {
 	let ms = durationMs;
 	if (isBeats) {
@@ -248,11 +212,8 @@ function anyMidiNotesSounding() {
 	return false;
 }
 
-/*
-Every note we know to be sounding, turned off, plus an all-notes-off on each
-channel touched as a backstop for anything we lost track of -- a note on sent
-as raw data, or one left over from before a reload.
-*/
+// All-notes-off per channel as well, for anything sent as raw data that we
+// never tracked.
 function midiPanic() {
 	if (!midi) return;
 	let channelsTouched = {};
@@ -275,14 +236,8 @@ function midiPanic() {
 	}
 }
 
-/*
-Reconnects one port that is already known by id.
-
-A port org is a value like any other, so it is saved with the document and
-comes back after a refresh -- with its name and id intact and nothing behind
-them, because requestMIDIAccess has not been called in the new session. This
-asks for access again and opens that one port, without listing everything.
-*/
+// A port org is saved with the document, so after a refresh it comes back as
+// just a name and an id. This asks for access again and opens that one port.
 function openMidiPort(portId, incb) {
 	let cb = function() {
 		let port = midi.outputs.get(portId);

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -194,10 +194,7 @@ function startRecordingAudio(wt, channel) {
 						// A wavetable holds one channel, so a stereo input is
 						// recorded one side at a time.
 						if (channel >= buffer.numberOfChannels) {
-							throw constructFatalError(
-									`cannot record channel ${channel}: this input has `
-									+ `${buffer.numberOfChannels} channel`
-									+ `${buffer.numberOfChannels == 1 ? '' : 's'}.`);
+							throw constructFatalError(`no input channel ${channel}. Sorry!`);
 						}
 						wt.setRecordedData(buffer.getChannelData(channel));
 					}, function(err) {


### PR DESCRIPTION
Stacked on #342. Was part of #341, which has been split.

Every error in the codebase ends with "Sorry!" and says one thing; the midi and audio channel errors added earlier in this stack were paragraphs instead. Seventeen of them, now one line each. Comments in the same files were trimmed at the same time.

Worth a reviewer's attention: this is error text and comments only, so the thing to check is that the shorter wording still says enough, and that nothing asserts on the old strings.
