### PR TITLE
[7/23] Add `do every`, a drift-corrected repeating timer

### DIFF
--- a/server/src/asyncfunctions.js
+++ b/server/src/asyncfunctions.js
@@ -20,6 +20,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 import { addMidiListener } from './midifunctions.js'
 import { convertJSMapToOrg } from './nex/org.js'
 import { VODKA_SCHEDULER } from './testutils/virtualclock.js'
+import { heap } from './heap.js'
 
 class ActivationFunctionGenerator {
 
@@ -189,10 +190,20 @@ class MidiActivationFunctionGenerator extends ActivationFunctionGenerator {
 }
 
 class EveryActivationFunctionGenerator extends ActivationFunctionGenerator {
-	constructor(intervalMs, onTick) {
+	/*
+	held is whatever onTick is going to call -- the lambda `do every` was given.
+	It is referenced from here and nowhere the document knows about, so without
+	saying so it can be deleted while the loop is still running: freed, its
+	lexical environment released, and then called every interval regardless.
+	*/
+	constructor(intervalMs, onTick, held) {
 		super();
 		this.intervalMs = intervalMs;
 		this.onTick = onTick;
+		this.held = held ? held : null;
+		if (this.held) {
+			heap.addReference(this.held);
+		}
 		this.timer = null;
 	}
 
@@ -221,6 +232,13 @@ class EveryActivationFunctionGenerator extends ActivationFunctionGenerator {
 		if (this.timer) {
 			window.clearTimeout(this.timer);
 			this.timer = null;
+		}
+		// stop can be reached more than once -- an error in the lambda, the stop
+		// button, the deferred being deleted -- and the reference is given up
+		// once
+		if (this.held) {
+			heap.removeReference(this.held);
+			this.held = null;
 		}
 	}
 

--- a/server/src/asyncfunctions.js
+++ b/server/src/asyncfunctions.js
@@ -202,7 +202,8 @@ class EveryActivationFunctionGenerator extends ActivationFunctionGenerator {
 			// so lateness does not accumulate. More than a whole interval
 			// missed means the skipped ones are dropped rather than fired in a
 			// burst.
-			let expected = performance.now() + this.intervalMs;
+			// The first one happens now, not an interval from now.
+			let expected = performance.now();
 			let tick = function() {
 				settleCallback(this.onTick());
 				let now = performance.now();
@@ -212,7 +213,7 @@ class EveryActivationFunctionGenerator extends ActivationFunctionGenerator {
 				}
 				this.timer = VODKA_SCHEDULER.setTimeout(tick, expected - now);
 			}.bind(this);
-			this.timer = VODKA_SCHEDULER.setTimeout(tick, this.intervalMs);
+			this.timer = VODKA_SCHEDULER.setTimeout(tick, 0);
 		}.bind(this);
 	}
 

--- a/server/src/asyncfunctions.js
+++ b/server/src/asyncfunctions.js
@@ -188,6 +188,46 @@ class MidiActivationFunctionGenerator extends ActivationFunctionGenerator {
 	}
 }
 
+class EveryActivationFunctionGenerator extends ActivationFunctionGenerator {
+	constructor(intervalMs, onTick) {
+		super();
+		this.intervalMs = intervalMs;
+		this.onTick = onTick;
+		this.timer = null;
+	}
+
+	getFunction(finishCallback, settleCallback, exp) {
+		return function() {
+			// Corrected against a running total, not against the last wake up,
+			// so lateness does not accumulate. More than a whole interval
+			// missed means the skipped ones are dropped rather than fired in a
+			// burst.
+			let expected = performance.now() + this.intervalMs;
+			let tick = function() {
+				settleCallback(this.onTick());
+				let now = performance.now();
+				expected += this.intervalMs;
+				if (expected < now) {
+					expected += Math.ceil((now - expected) / this.intervalMs) * this.intervalMs;
+				}
+				this.timer = VODKA_SCHEDULER.setTimeout(tick, expected - now);
+			}.bind(this);
+			this.timer = VODKA_SCHEDULER.setTimeout(tick, this.intervalMs);
+		}.bind(this);
+	}
+
+	stop() {
+		if (this.timer) {
+			window.clearTimeout(this.timer);
+			this.timer = null;
+		}
+	}
+
+	getAFGName() {
+		return 'every';
+	}
+}
+
 class OnContentsChangedActivationFunctionGenerator extends ActivationFunctionGenerator {
 	constructor(nex) {
 		super();
@@ -211,6 +251,7 @@ class OnContentsChangedActivationFunctionGenerator extends ActivationFunctionGen
 export {
 	ImmediateActivationFunctionGenerator,
 	DelayActivationFunctionGenerator,
+	EveryActivationFunctionGenerator,
 	ClickActivationFunctionGenerator,
 	GenericActivationFunctionGenerator,
 	MidiActivationFunctionGenerator,

--- a/server/src/builtins/asyncbuiltins.js
+++ b/server/src/builtins/asyncbuiltins.js
@@ -28,6 +28,9 @@ import { experiments } from '../globalappflags.js'
 import { Tag } from '../tag.js'
 import { constructDeferredValue } from '../nex/deferredvalue.js'
 import { incFFGen } from '../gc.js'
+import { constructInteger } from '../nex/integer.js'
+import { constructFatalError } from '../nex/eerror.js'
+import { BINDINGS } from '../environment.js'
 import { constructBool } from '../nex/bool.js'; 
 import { systemState } from '../systemstate.js'
 import { evaluateNexSafely, wrapError } from '../evaluator.js'
@@ -36,6 +39,7 @@ import { evaluateNexSafely, wrapError } from '../evaluator.js'
 import {
 	ImmediateActivationFunctionGenerator,
 	DelayActivationFunctionGenerator,
+	EveryActivationFunctionGenerator,
 	ClickActivationFunctionGenerator,
 	OnContentsChangedActivationFunctionGenerator,
 	CallbackActivationFunctionGenerator,
@@ -43,6 +47,24 @@ import {
 } from '../asyncfunctions.js'
 
 
+
+// running `do every` loops, so the stop button can end them
+const runningLoops = {};
+let nextLoopId = 1;
+
+function stopAllLoops() {
+	for (let id in runningLoops) {
+		runningLoops[id].stop();
+		delete runningLoops[id];
+	}
+}
+
+function anyLoopsRunning() {
+	for (let id in runningLoops) {
+		return true;
+	}
+	return false;
+}
 
 function createAsyncBuiltins() {
 
@@ -178,6 +200,42 @@ function createAsyncBuiltins() {
 		'Returns a deferred value that settles every time |nex is clicked on.'
 	);
 
+
+	Builtin.createBuiltin(
+		'do every',
+		[ 'f&', 'interval#' ],
+		function $doEvery(env, executionEnvironment) {
+			let f = env.lb('f');
+			let intervalnex = env.lb('interval');
+			let ms = intervalnex.getTypedValue();
+			if (!(ms > 0)) {
+				return constructFatalError('do every: interval must be more than zero. Sorry!');
+			}
+
+			let id = nextLoopId++;
+			let seq = 0;
+			let afg = new EveryActivationFunctionGenerator(ms, function() {
+				let cmd = systemState.getSCF().makeCommandWithClosureOneArg(f, constructInteger(seq));
+				let r = systemState.getSCF().sEval2(cmd, BINDINGS, 'do every');
+				seq++;
+				if (Utils.isFatalError(r)) {
+					afg.stop();
+					delete runningLoops[id];
+				}
+				return r;
+			});
+
+			let dv = constructDeferredValue();
+			// a deferred renders and serializes through its first child
+			dv.appendChild(intervalnex);
+			dv.set(afg);
+			dv.activate();
+			runningLoops[id] = afg;
+			return dv;
+		},
+		'Returns a deferred value that settles every |interval milliseconds with whatever |f returned. The first one happens straight away. |f is passed the number of times it has run, starting at zero, which it can take as an argument or ignore. Stops if |f returns a fatal error, when the deferred value is deleted, or when the stop button is pressed.'
+	);
+
 	Builtin.createBuiltin(
 		'wait-for-delay',
 		[ 'time#' ],
@@ -225,5 +283,5 @@ function createAsyncBuiltins() {
 	);
 }
 
-export { createAsyncBuiltins }
+export { createAsyncBuiltins, stopAllLoops, anyLoopsRunning }
 

--- a/server/src/builtins/asyncbuiltins.js
+++ b/server/src/builtins/asyncbuiltins.js
@@ -223,7 +223,7 @@ function createAsyncBuiltins() {
 					delete runningLoops[id];
 				}
 				return r;
-			});
+			}, f);
 
 			let dv = constructDeferredValue();
 			// a deferred renders and serializes through its first child

--- a/server/src/builtins/syscalls.js
+++ b/server/src/builtins/syscalls.js
@@ -30,6 +30,8 @@ import { rootManager } from '../rootmanager.js'
 import { experiments, getExperimentsAsString, getSettings, setSettingValue, hasSettingName } from '../globalappflags.js'
 import { UNBOUND, BINDINGS } from '../environment.js'
 import { convertTimeToSamples, getSampleRate } from '../wavetablefunctions.js'
+import { constructDeferredValue } from '../nex/deferredvalue.js'
+import { EveryActivationFunctionGenerator } from '../asyncfunctions.js'
 import { webFontManager } from '../webfonts.js'
 import {
 	RENDER_MODE_NORM,
@@ -45,7 +47,7 @@ let nextLoopId = 1;
 
 function stopAllLoops() {
 	for (let id in runningLoops) {
-		window.clearTimeout(runningLoops[id]);
+		runningLoops[id].stop();
 		delete runningLoops[id];
 	}
 }
@@ -145,32 +147,24 @@ function createSyscalls() {
 
 			let id = nextLoopId++;
 			let seq = 0;
-			let expected = performance.now() + ms;
-
-			function tick() {
-				if (!runningLoops[id]) return;
+			let afg = new EveryActivationFunctionGenerator(ms, function() {
 				let cmd = systemState.getSCF().makeCommandWithClosureOneArg(f, constructInteger(seq));
 				let r = systemState.getSCF().sEval2(cmd, BINDINGS, 'do every');
 				seq++;
 				if (Utils.isFatalError(r)) {
+					afg.stop();
 					delete runningLoops[id];
-					return;
 				}
-				// Correcting against a running total rather than the last wake
-				// up, so lateness does not accumulate. If more than a whole
-				// interval was missed the skipped ones are dropped rather than
-				// fired in a burst to catch up.
-				let now = performance.now();
-				expected += ms;
-				if (expected < now) {
-					expected += Math.ceil((now - expected) / ms) * ms;
-				}
-				runningLoops[id] = window.setTimeout(tick, expected - now);
-			}
-			runningLoops[id] = window.setTimeout(tick, ms);
-			return f;
+				return r;
+			});
+
+			let dv = constructDeferredValue();
+			dv.set(afg);
+			dv.activate();
+			runningLoops[id] = afg;
+			return dv;
 		},
-		'Runs |f every |interval, forever. |interval takes a timebase tag like any other length. |f is passed the number of times it has run, starting at zero, which it can take as an argument or ignore. Stops if |f returns a fatal error, or when the stop button is pressed.'
+		'Returns a deferred value that settles every |interval with whatever |f returned. |interval takes a timebase tag like any other length. |f is passed the number of times it has run, starting at zero, which it can take as an argument or ignore. Stops if |f returns a fatal error, or when the stop button is pressed.'
 	);
 
 	Builtin.createBuiltin(

--- a/server/src/builtins/syscalls.js
+++ b/server/src/builtins/syscalls.js
@@ -28,10 +28,7 @@ import { RenderNode } from '../rendernode.js'
 import { systemState } from '../systemstate.js'
 import { rootManager } from '../rootmanager.js'
 import { experiments, getExperimentsAsString, getSettings, setSettingValue, hasSettingName } from '../globalappflags.js'
-import { UNBOUND, BINDINGS } from '../environment.js'
-import { convertTimeToSamples, getSampleRate } from '../wavetablefunctions.js'
-import { constructDeferredValue } from '../nex/deferredvalue.js'
-import { EveryActivationFunctionGenerator } from '../asyncfunctions.js'
+import { UNBOUND } from '../environment.js'
 import { webFontManager } from '../webfonts.js'
 import {
 	RENDER_MODE_NORM,
@@ -41,24 +38,6 @@ import {
 /**
  * Creates all syscall builtins.
  */
-// running `do every` loops, so the stop button can end them
-const runningLoops = {};
-let nextLoopId = 1;
-
-function stopAllLoops() {
-	for (let id in runningLoops) {
-		runningLoops[id].stop();
-		delete runningLoops[id];
-	}
-}
-
-function anyLoopsRunning() {
-	for (let id in runningLoops) {
-		return true;
-	}
-	return false;
-}
-
 function createSyscalls() {
 
 	Builtin.createBuiltin(
@@ -133,42 +112,6 @@ function createSyscalls() {
 
 
 	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
-
-	Builtin.createBuiltin(
-		'do every',
-		[ 'f&', 'interval' ],
-		function $doEvery(env, executionEnvironment) {
-			let f = env.lb('f');
-			let interval = env.lb('interval');
-			let ms = (convertTimeToSamples(interval) / getSampleRate()) * 1000;
-			if (!(ms > 0)) {
-				return constructFatalError('do every: interval must be more than zero. Sorry!');
-			}
-
-			let id = nextLoopId++;
-			let seq = 0;
-			let afg = new EveryActivationFunctionGenerator(ms, function() {
-				let cmd = systemState.getSCF().makeCommandWithClosureOneArg(f, constructInteger(seq));
-				let r = systemState.getSCF().sEval2(cmd, BINDINGS, 'do every');
-				seq++;
-				if (Utils.isFatalError(r)) {
-					afg.stop();
-					delete runningLoops[id];
-				}
-				return r;
-			});
-
-			let dv = constructDeferredValue();
-			// Needs a child: a deferred renders and serializes through its first
-			// one, so an empty one cannot be drawn or saved.
-			dv.appendChild(interval);
-			dv.set(afg);
-			dv.activate();
-			runningLoops[id] = afg;
-			return dv;
-		},
-		'Returns a deferred value that settles every |interval with whatever |f returned. |interval takes a timebase tag like any other length. |f is passed the number of times it has run, starting at zero, which it can take as an argument or ignore. Stops if |f returns a fatal error, or when the stop button is pressed.'
-	);
 
 	Builtin.createBuiltin(
 		'get-time',
@@ -320,5 +263,5 @@ function createSyscalls() {
 	);
 }
 
-export { createSyscalls, stopAllLoops, anyLoopsRunning }
+export { createSyscalls }
 

--- a/server/src/builtins/syscalls.js
+++ b/server/src/builtins/syscalls.js
@@ -159,6 +159,9 @@ function createSyscalls() {
 			});
 
 			let dv = constructDeferredValue();
+			// Needs a child: a deferred renders and serializes through its first
+			// one, so an empty one cannot be drawn or saved.
+			dv.appendChild(interval);
 			dv.set(afg);
 			dv.activate();
 			runningLoops[id] = afg;

--- a/server/src/builtins/syscalls.js
+++ b/server/src/builtins/syscalls.js
@@ -28,7 +28,8 @@ import { RenderNode } from '../rendernode.js'
 import { systemState } from '../systemstate.js'
 import { rootManager } from '../rootmanager.js'
 import { experiments, getExperimentsAsString, getSettings, setSettingValue, hasSettingName } from '../globalappflags.js'
-import { UNBOUND } from '../environment.js'
+import { UNBOUND, BINDINGS } from '../environment.js'
+import { convertTimeToSamples, getSampleRate } from '../wavetablefunctions.js'
 import { webFontManager } from '../webfonts.js'
 import {
 	RENDER_MODE_NORM,
@@ -38,6 +39,24 @@ import {
 /**
  * Creates all syscall builtins.
  */
+// running `do every` loops, so the stop button can end them
+const runningLoops = {};
+let nextLoopId = 1;
+
+function stopAllLoops() {
+	for (let id in runningLoops) {
+		window.clearTimeout(runningLoops[id]);
+		delete runningLoops[id];
+	}
+}
+
+function anyLoopsRunning() {
+	for (let id in runningLoops) {
+		return true;
+	}
+	return false;
+}
+
 function createSyscalls() {
 
 	Builtin.createBuiltin(
@@ -108,6 +127,50 @@ function createSyscalls() {
 			return constructNil();
 		},
 		'Disconnects the event funnel (used to disable IDE features).'
+	);
+
+
+	// - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -  - -
+
+	Builtin.createBuiltin(
+		'do every',
+		[ 'f&', 'interval' ],
+		function $doEvery(env, executionEnvironment) {
+			let f = env.lb('f');
+			let interval = env.lb('interval');
+			let ms = (convertTimeToSamples(interval) / getSampleRate()) * 1000;
+			if (!(ms > 0)) {
+				return constructFatalError('do every: interval must be more than zero. Sorry!');
+			}
+
+			let id = nextLoopId++;
+			let seq = 0;
+			let expected = performance.now() + ms;
+
+			function tick() {
+				if (!runningLoops[id]) return;
+				let cmd = systemState.getSCF().makeCommandWithClosureOneArg(f, constructInteger(seq));
+				let r = systemState.getSCF().sEval2(cmd, BINDINGS, 'do every');
+				seq++;
+				if (Utils.isFatalError(r)) {
+					delete runningLoops[id];
+					return;
+				}
+				// Correcting against a running total rather than the last wake
+				// up, so lateness does not accumulate. If more than a whole
+				// interval was missed the skipped ones are dropped rather than
+				// fired in a burst to catch up.
+				let now = performance.now();
+				expected += ms;
+				if (expected < now) {
+					expected += Math.ceil((now - expected) / ms) * ms;
+				}
+				runningLoops[id] = window.setTimeout(tick, expected - now);
+			}
+			runningLoops[id] = window.setTimeout(tick, ms);
+			return f;
+		},
+		'Runs |f every |interval, forever. |interval takes a timebase tag like any other length. |f is passed the number of times it has run, starting at zero, which it can take as an argument or ignore. Stops if |f returns a fatal error, or when the stop button is pressed.'
 	);
 
 	Builtin.createBuiltin(
@@ -260,5 +323,5 @@ function createSyscalls() {
 	);
 }
 
-export { createSyscalls }
+export { createSyscalls, stopAllLoops, anyLoopsRunning }
 

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -1376,9 +1376,11 @@ function createWavetableBuiltins() {
     function $millisecondsOf(env, executionEnvironment) {
       let len = env.lb("len");
       let ms = (convertTimeToSamples(len) / getSampleRate()) * 1000;
-      return constructFloat(ms);
+      // setTimeout drops anything after the decimal point, so a float here
+      // would only be rounded later, somewhere less obvious.
+      return constructInteger(Math.round(ms));
     },
-    "Returns the length of |len in milliseconds. |len takes a timebase tag like any other length, so this is how a length in beats becomes a number that something outside the audio system can use."
+    "Returns the length of |len in whole milliseconds, rounded. |len takes a timebase tag like any other length, so this is how a length in beats becomes a number that something outside the audio system can use."
   );
 
   Builtin.createBuiltin(

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -1371,6 +1371,17 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
+    "milliseconds-of",
+    ["len"],
+    function $millisecondsOf(env, executionEnvironment) {
+      let len = env.lb("len");
+      let ms = (convertTimeToSamples(len) / getSampleRate()) * 1000;
+      return constructFloat(ms);
+    },
+    "Returns the length of |len in milliseconds. |len takes a timebase tag like any other length, so this is how a length in beats becomes a number that something outside the audio system can use."
+  );
+
+  Builtin.createBuiltin(
     "get-bpm",
     [],
     function $getBpm(env, executionEnvironment) {

--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { isAnySoundPlaying, stopAllSound } from '../webaudio.js';
 import { anyMidiNotesSounding, midiPanic } from '../midifunctions.js';
+import { stopAllLoops, anyLoopsRunning } from '../builtins/syscalls.js';
 import { hasPendingSave } from '../autosave.js';
 
 // Neither playback nor the save debounce announces itself, so poll. Cheap --
@@ -15,7 +16,7 @@ const StatusNav = () => {
         const id = setInterval(() => {
             // a midi note left sounding is the same kind of problem as audio
             // still running, and more urgent -- nothing stops it on its own
-            setPlaying(isAnySoundPlaying() || anyMidiNotesSounding());
+            setPlaying(isAnySoundPlaying() || anyMidiNotesSounding() || anyLoopsRunning());
             setUnsaved(hasPendingSave());
         }, POLL_MS);
         return () => clearInterval(id);
@@ -25,8 +26,8 @@ const StatusNav = () => {
         <div className="statusnav">
             {unsaved && <div className="unsaveddot" title="not saved yet"></div>}
             {playing &&
-                <div className="statusnavitem stopbutton" title="stop all sound and midi notes"
-                     onClick={() => { stopAllSound(); midiPanic(); setPlaying(false); }}>
+                <div className="statusnavitem stopbutton" title="stop everything"
+                     onClick={() => { stopAllSound(); midiPanic(); stopAllLoops(); setPlaying(false); }}>
                     {/* currentColor so the icon follows the theme token on the parent */}
                     <svg viewBox="0 0 8 9" width="8" height="9" aria-hidden="true">
                         <rect x="0" y="0" width="3" height="9" fill="currentColor"/>

--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'preact/hooks';
 import { isAnySoundPlaying, stopAllSound } from '../webaudio.js';
 import { anyMidiNotesSounding, midiPanic } from '../midifunctions.js';
-import { stopAllLoops, anyLoopsRunning } from '../builtins/syscalls.js';
+import { stopAllLoops, anyLoopsRunning } from '../builtins/asyncbuiltins.js';
 import { hasPendingSave } from '../autosave.js';
 
 // Neither playback nor the save debounce announces itself, so poll. Cheap --

--- a/server/src/nex/deferredvalue.js
+++ b/server/src/nex/deferredvalue.js
@@ -102,9 +102,10 @@ class DeferredValue extends NexContainer {
 	toStringV2(ctx) {
 		// I think deferred values should just save as not a container but rather save as the string of its
 		// contained value, whatever that is. We can't, for example, save the state of a file read operation that is in progress.
+		// It can have no contained value at all -- `wait` with no argument makes
+		// one, and so does anything still waiting for its first result. Nothing
+		// is nil.
 		let c = this.getChildAt(0);
-		// A deferred with nothing in it yet is a bug in whatever made it, but it
-		// should not take autosave down with it.
 		return c ? c.toStringV2(ctx) : '[nil]';
 	}
 

--- a/server/src/nex/deferredvalue.js
+++ b/server/src/nex/deferredvalue.js
@@ -102,7 +102,10 @@ class DeferredValue extends NexContainer {
 	toStringV2(ctx) {
 		// I think deferred values should just save as not a container but rather save as the string of its
 		// contained value, whatever that is. We can't, for example, save the state of a file read operation that is in progress.
-		return this.getChildAt(0).toStringV2();
+		let c = this.getChildAt(0);
+		// A deferred with nothing in it yet is a bug in whatever made it, but it
+		// should not take autosave down with it.
+		return c ? c.toStringV2(ctx) : '[nil]';
 	}
 
 	// deferred values are containers but we don't let you insert things in the editor

--- a/server/src/nex/deferredvalue.js
+++ b/server/src/nex/deferredvalue.js
@@ -111,6 +111,17 @@ class DeferredValue extends NexContainer {
 	}
 
 	// rename this
+	/*
+	Some activation sources hold something that keeps running whether or not
+	anyone is still listening -- a repeating timer, most obviously. Deleting the
+	deferred should stop it.
+	*/
+	cleanupOnMemoryFree() {
+		if (this.activationFunctionGenerator && this.activationFunctionGenerator.stop) {
+			this.activationFunctionGenerator.stop();
+		}
+	}
+
 	set(activationFunctionGenerator) {
 		this.activationFunctionGenerator = activationFunctionGenerator;
 		this.ffgen = getFFGen();


### PR DESCRIPTION
Rescoped: this PR was carrying six separate pieces of work. It is now just `do every` and the deferred-value fixes it needed. The rest is split into #352, #353, #354 and #355.

`do every` takes a lambda and an interval in milliseconds, fires immediately, corrects for drift, and skips ticks rather than piling them up when it falls behind. It returns a repeating deferred value, and passes a sequence number into the lambda.

Deferred-value fixes it turned up along the way:

- a repeating deferred stops when it is deleted
- a deferred with no children can be saved (an empty one was breaking autosave)
- `do every` holds a reference to the lambda it is running, so the lambda is not freed underneath it
- `milliseconds-of` returns a whole number