### PR TITLE
[12/23] Draw contracts, clips and closures the same way

### DIFF
--- a/server/src/css/clip.css
+++ b/server/src/css/clip.css
@@ -22,13 +22,6 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	display: none;
 }
 
-.cglyph {
-	font-size: 20px;
-	font-family: Courier;
-	padding-right: 10px;
-	color: var(--clip-glyph);
-}
-
 .clip.exploded {
 	border-radius: 6px;
 	font-style: italic;
@@ -41,6 +34,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	background-color: var(--value-background);
 	border: 1px solid var(--unselected-border);
 	padding-right: 6px;
+	padding-left: 4px;
 	padding-bottom: 6px;
 	padding-top: 6px;
 }
@@ -49,18 +43,11 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	border: 3px solid var(--selected-border);
 }
 
-.clipframe {
-	display: flex;
-	flex-direction: row;
-	padding-bottom: 6px;
-}
-
-.cinnerspans {
-	flex-direction: column;
-	display: flex;
-}
-
 .clippos {
 	font-variant-numeric: tabular-nums;
 	color: var(--clip-position);
+}
+
+.clip .sysglyph {
+	color: var(--clip-glyph);
 }

--- a/server/src/css/contract.css
+++ b/server/src/css/contract.css
@@ -20,13 +20,6 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	display: none;
 }
 
-.cglyph {
-	font-size: 20px;
-	font-family: Courier;
-	padding-right: 10px;
-
-}
-
 .contract.exploded {
 	border-radius: 6px;	
 	font-style: italic;
@@ -40,6 +33,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	background-color: var(--value-background);
 	border: 1px solid var(--unselected-border);
 	padding-right: 6px;
+	padding-left: 4px;
 	padding-bottom: 6px;
 	padding-top: 6px;
 }
@@ -53,19 +47,10 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	margin-left: 27px;
 }
 
-.contractframe {
-	display: flex;
-	flex-direction: row;
-	padding-bottom: 6px;
-}
-
-.cinnerspans {
-	flex-direction: column;
-	display: flex;
-
-}
-
-
 .contract.exploded.newselected {
 	border: 3px solid var(--selected-border);
+}
+
+.contract .sysglyph {
+	color: var(--contract-glyph);
 }

--- a/server/src/css/systemnex.css
+++ b/server/src/css/systemnex.css
@@ -15,26 +15,27 @@ You should have received a copy of the GNU General Public License
 along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+/*
+Contracts, clips and closures are all things the system hands you rather than
+things you type, and they are drawn the same way so you can tell at a glance
+which is which: a glyph naming the kind, and beside it the lines that say what
+this particular one is.
+*/
 
+.sysframe {
+	display: flex;
+	flex-direction: row;
+	padding-bottom: 6px;
+}
 
+.sysglyph {
+	font-size: 20px;
+	font-family: Courier;
+	margin-left: 6px;
+	padding-right: 8px;
+}
 
-.closure.exploded {
+.sysinnerspans {
+	display: flex;
 	flex-direction: column;
-	align-items: flex-start;
-	max-width: 400px;
-	padding-left: 4px;
-}
-
-.closure .sysglyph {
-	font-weight: bold;
-	color: var(--closure-glyph);
-}
-
-.closureline1 {
-	font-weight: bold;
-}
-
-.closureline4,
-.closureline5 {
-	font-size: .9em;
 }

--- a/server/src/css/theme.css
+++ b/server/src/css/theme.css
@@ -82,6 +82,8 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
   --wave-playhead: #0ec43f;
   --clip-glyph: #736b0d;
   --clip-position: #8a8a8a;
+  --contract-glyph: #736b0d;
+  --closure-glyph: #736b0d;
   --wave-canvas-background: #ffffff;
   --wave-endcap-1: #ffffff;
   --wave-endcap-2: #dddddd;
@@ -166,6 +168,8 @@ waveform is teal so signal is never confused with structure.
   --wave-playhead: #4ade80;
   --clip-glyph: #7fbdb8;
   --clip-position: #9aa0a6;
+  --contract-glyph: #7fbdb8;
+  --closure-glyph: #7fbdb8;
   --wave-canvas-background: #0a0a0a;
   --wave-endcap-1: #0a0a0a;
   --wave-endcap-2: #141414;

--- a/server/src/host.html
+++ b/server/src/host.html
@@ -37,6 +37,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 	<link rel="stylesheet" href="css/letter.css">
 	<link rel="stylesheet" href="css/nil.css">
 	<link rel="stylesheet" href="css/wavetable.css">
+	<link rel="stylesheet" href="css/systemnex.css">
 	<link rel="stylesheet" href="css/clip.css">
 	<link rel="stylesheet" href="css/surface.css">
 	<link rel="stylesheet" href="css/separator.css">

--- a/server/src/nex/clip.js
+++ b/server/src/nex/clip.js
@@ -141,14 +141,14 @@ class Clip extends Nex {
 		domNode.classList.add('clip');
 
 		let frame = document.createElement('div');
-		frame.classList.add('clipframe');
+		frame.classList.add('sysframe');
 
 		let glyph = document.createElement('div');
-		glyph.classList.add('cglyph');
+		glyph.classList.add('sysglyph');
 		glyph.innerHTML = '&#8734;'; // it goes round until you stop it
 
 		let innerspans = document.createElement('div');
-		innerspans.classList.add('cinnerspans');
+		innerspans.classList.add('sysinnerspans');
 
 		let line1 = document.createElement('div');
 		line1.classList.add('innerspan');

--- a/server/src/nex/closure.js
+++ b/server/src/nex/closure.js
@@ -127,7 +127,7 @@ class Closure extends ValueNex {
 	}
 
 	closureline(n, s) {
-		return `<div class="closureline${n}">${s.trim()}</div>`
+		return `<div class="innerspan closureline${n}">${s.trim()}</div>`
 	}
 
 	getSummaryLine() {
@@ -158,13 +158,18 @@ class Closure extends ValueNex {
 		}
 	}
 
+	// Drawn like a contract or a clip: the prefix becomes the glyph, and
+	// everything that describes this particular closure stacks up beside it.
 	getRenderedHTML() {
-		return this.closureline('0', this.prefix) +
-		    this.closureline('1', this.getSummaryLine()) +
+		return '<div class="sysframe">' +
+			`<div class="sysglyph">${this.prefix}</div>` +
+			'<div class="sysinnerspans">' +
+			this.closureline('1', this.getSummaryLine()) +
 			this.closureline('2', this.getLambdaArgString()) +
 			this.closureline('3', this.getDocString()) +
 			this.closureline('4', this.getLambdaDebugString()) +
-			this.closureline('5', this.getEnvironmentLine());
+			this.closureline('5', this.getEnvironmentLine()) +
+			'</div></div>';
 	}
 
 	renderValue() {

--- a/server/src/nex/contract.js
+++ b/server/src/nex/contract.js
@@ -115,10 +115,10 @@ class Contract extends NexContainer {
 		domNode.classList.add('contract');
 
 		let frame = document.createElement('div');
-		frame.classList.add('contractframe');
+		frame.classList.add('sysframe');
 
 		let glyph = document.createElement('div');
-		glyph.classList.add('cglyph');
+		glyph.classList.add('sysglyph');
 		if (this.numChildren() > 0) {
 			glyph.innerHTML = '&#8225;'; // double dagger
 		} else {
@@ -126,7 +126,7 @@ class Contract extends NexContainer {
 		}
 
 		let innerspans = document.createElement('div');
-		innerspans.classList.add('cinnerspans')
+		innerspans.classList.add('sysinnerspans')
 
 		let innerspan = document.createElement("div");
 		innerspan.classList.add('innerspan');


### PR DESCRIPTION
Stacked on #349.

Contracts and clips are drawn as a glyph with labelled lines beside it. Closures are the same sort of thing — something the system hands you rather than something you type — but were laid out completely differently, with the prefix on its own line and everything else indented under it. Now the prefix is the glyph and the rest stacks up beside it.

The frame, glyph and stack are one set of classes in a new `css/systemnex.css`, shared by all three.

**This fixes a real collision.** Contract and clip had each defined their own `.cglyph` and `.cinnerspans`. Only the clip's copy set a colour, so contracts were picking it up and the dagger was rendering in the clip's teal. Each kind now names its own glyph colour token, in both themes.

Also: a little more room to the left of the glyph, which is what prompted this.

Two things a reviewer might notice:
- Closure line 1 and line 2 both show a bare `|` for an unnamed closure. That is not decoration — `symbolBinding` defaults to `'|'`, standing in for the name it has not got, and line 2 would read `myfunc |a |b` for a named one. I dropped line 1 at one point and put it back.
- `.closure.exploded` was `width: 400px` and is now `max-width`, so it shrinks to fit like the other two.