### PR TITLE
[13/23] Keep contracts and closures out of save files

### DIFF
--- a/server/src/nex/clip.js
+++ b/server/src/nex/clip.js
@@ -45,6 +45,8 @@ class Clip extends Nex {
 		this.ended = false;
 		this.posFrame = null;
 		this.posSpan = null;
+		// nothing here is yours to type over
+		this.setMutable(false);
 	}
 
 	getTypeName() {
@@ -64,11 +66,9 @@ class Clip extends Nex {
 	}
 
 	/*
-	A clip evaluates to itself rather than to a copy, which is what lets it sit
-	in the expression that made it: loop-play hands back the very clip it was
-	given, so re-evaluating can throw the result away and the clip is still
-	there in the expression, still naming the loop it did before. A copy would
-	be a picture of it, and the ids would go stale the first time round.
+	Never a copy, whatever the mutable flag says: a copy of a clip is a picture
+	of it and cannot stop the loop, so an expression holding one would go on
+	naming a loop it could no longer reach.
 	*/
 	evaluate(env) {
 		return this;

--- a/server/src/nex/closure.js
+++ b/server/src/nex/closure.js
@@ -45,13 +45,25 @@ class Closure extends ValueNex {
 
 		this.lexicalEnvironment = lexicalEnvironment;
 		heap.addEnvReference(this.lexicalEnvironment);
+		// nothing here is yours to type over
+		this.setMutable(false);
 	}
 
 	toString(version, ctx) {
 		if (version == 'v2') {
-			return `[CLOSURE FOR: ${this.lambda.prettyPrint()}]`;
+			return this.toStringV2(ctx);
 		}
 		return super.toString(version);
+	}
+
+	/*
+	A closure is a runtime thing and is never written to a file: it holds a
+	lexical environment, which does not outlive the session. It saves as nil,
+	the same as a contract or a clip. What it used to write was a description
+	of itself with spaces and an expression in it, which nothing could read.
+	*/
+	toStringV2(ctx) {
+		return '[nil]';
 	}
 
 	// According to what I wrote in my blog, I should not really copy

--- a/server/src/nex/contract.js
+++ b/server/src/nex/contract.js
@@ -27,6 +27,8 @@ class Contract extends NexContainer {
 
 		super()
 		this.impl = contractImpl;
+		// nothing here is yours to type over
+		this.setMutable(false);
 		// A contract has no private data of its own, but it still gets
 		// serialized like everything else, and '' is what "nothing" looks like
 		// to a serializer. null is not a string.
@@ -44,7 +46,7 @@ class Contract extends NexContainer {
 
 	toString(version, ctx) {
 		if (version == 'v2') {
-			return `[CONTRACT]`;
+			return this.toStringV2(ctx);
 		}
 		return super.toString(version);
 	}
@@ -53,8 +55,14 @@ class Contract extends NexContainer {
 		return this.standardListPrettyPrint(lvl, '[contract]', hdir);
 	}
 
+	/*
+	A contract is a runtime thing and is never written to a file: it names an
+	identity that only exists while this session is running, so reading one
+	back would name something that is not there. It saves as nil, the same as
+	a clip or an empty deferred.
+	*/
 	toStringV2(ctx) {
-		return `${this.toStringV2Literal()}${this.toStringV2PrivateDataSection(ctx)}${this.listStartV2()}${this.toStringV2TagList()}${super.childrenToString('v2', ctx)}${this.listEndV2()}`;
+		return '[nil]';
 	}
 
 	deserializePrivateData(data) {


### PR DESCRIPTION
Stacked on #350.

Contract, closure and clip are runtime-only: one names an identity, one holds a lexical environment, one names a loop on the cycle. None outlives the session, so none belongs in a file. Only the clip was obeying that.

**Contracts were being written as `[CONTRACT]` and closures as `[CLOSURE FOR: <expression>]`.** The parser has no case for either — it knows nothing about any of the three types — so both were garbage in the file. The closure form is the alarming one: it carries spaces and nested syntax inside an instance atom, sitting in the middle of a document, which can take the rest of the parse down with it rather than just losing the closure. Both save as `[nil]` now, which is a real parse case and reads back as an empty slot.

Separately, all three are `setMutable(false)` at construction. In vodka `mutable` means the user can edit it in the UI, and none of the three has an editor. This is the established pattern — `org`, `integer`, `word`, `line`, `doc`, `bool`, `float` and `estring` all do it in their constructors.

Contract keeps its `evaluate` override regardless, and it is load-bearing: `decorateNex` sets `mutable = true` on everything the parser reads that has no immutable sigil, so a contract can come back from a file mutable whatever its constructor did. The clip has the same override for a different reason — a copy of a clip cannot stop its loop, so it must never be copied on evaluation.

**Visible change:** closures were mutable, and `.valuenex.mutable` gives a 3px border. They will now draw with the 1px border, matching contracts and clips.