### PR TITLE
[6/23] Record through an audio worklet, and decode a recording once

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -148,7 +148,7 @@ function createWavetableBuiltins() {
   Builtin.createBuiltin(
     "start-recording",
     ["_wt_", "channel#?"],
-    function $startRecording(env, executionEnvironment) {
+    function $startRecording(env, executionEnvironment, commandTags) {
       let wt = env.lb("wt");
       let channel = env.lb("channel");
       // 1-based to the user, the way audio hardware numbers channels
@@ -156,10 +156,16 @@ function createWavetableBuiltins() {
       if (n < 1) {
         return constructFatalError("start-recording: there is no channel " + n + ". Sorry!");
       }
-      startRecordingAudio(wt, n - 1);
+      let unlimited = false;
+      for (let i = 0; commandTags && i < commandTags.length; i++) {
+        if (commandTags[i].getTagString() == "unlimited") {
+          unlimited = true;
+        }
+      }
+      startRecordingAudio(wt, n - 1, unlimited);
       return wt;
     },
-    "Tells |wt to record from |channel (or channel 1 if |channel is not given). A wavetable holds one channel, so a stereo input is recorded one side at a time."
+    "Tells |wt to record from |channel (or channel 1 if |channel is not given). A wavetable holds one channel, so a stereo input is recorded one side at a time. Recording stops after 30 seconds unless this command is tagged `unlimited`."
   );
 
   Builtin.createBuiltin(

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -165,7 +165,8 @@ class Wavetable extends Nex {
 		this.markers = [];
 		this.sectionBeingAuditioned = null;
 		this.recording = false;
-		this.blobs = [];
+		this.recordedChunks = null;
+		this.recordedLength = 0;
 		this.currentTimebase = null;
 		this.rightIsClipping = false;
 
@@ -202,30 +203,52 @@ class Wavetable extends Nex {
 		}
 	}
 
-	addBlob(blob) {
-		this.blobs.push(blob);
-	}
-
-	getBlobsAsOneBlob(blob) {
-		return new Blob(this.blobs);
-	}
-
-	resetBlobs() {
-		this.blobs = [];
-	}
-
 	isRecording() {
 		return this.recording;
 	}
 
 	startRecording() {
 		this.data = new Float32Array();
-		this.resetBlobs();
+		this.recordedChunks = [];
+		this.recordedLength = 0;
 		this.recording = true;
+		this.setDirtyForRendering(true);
+		eventQueueDispatcher.enqueueTopLevelRender();
+	}
+
+	/*
+	Samples as they arrive, while recording.
+
+	The blocks are kept as they come and joined into one buffer at each render
+	rather than growing a single array by copying it every time. cacheValues is
+	deliberately not called: it walks the whole buffer for the amplitude and
+	builds an AudioBuffer, neither of which is wanted several times a second,
+	and neither of which the waveform display needs. stopRecording does it once
+	at the end.
+	*/
+	appendRecordedData(block) {
+		this.recordedChunks.push(block);
+		this.recordedLength += block.length;
+		let joined = new Float32Array(this.recordedLength);
+		let at = 0;
+		for (let i = 0; i < this.recordedChunks.length; i++) {
+			joined.set(this.recordedChunks[i], at);
+			at += this.recordedChunks[i].length;
+		}
+		this.data = joined;
+		this.setDirtyForRendering(true);
+		eventQueueDispatcher.enqueueTopLevelRender();
 	}
 
 	stopRecording() {
 		this.recording = false;
+		this.recordedChunks = null;
+		if (this.data.length == 0) {
+			// nothing arrived; a wavetable cannot be zero samples long
+			this.data = new Float32Array(DEFAULT_SIZE);
+		}
+		// the amplitude and the playback buffer, once, now that it is over
+		this.cacheValues();
 		this.setDirtyForRendering(true);
 		eventQueueDispatcher.enqueueTopLevelRender();			
 	}

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -39,6 +39,10 @@ let auditioningPlayer = null;
 
 let mediaRecorder = null;
 
+// A guardrail, not a real limit -- so a first recording cannot fill the disk
+// before anyone knows how to stop it. The `unlimited` tag lifts it.
+const RECORDING_LIMIT_MS = 30000;
+
 class AuditionPlayer {
 	// sustained means the sound keeps going after the key comes back up. Holding
 	// enter to audition is momentary; toggling playback with space is not.
@@ -169,7 +173,7 @@ function stopRecordingAudio(wt) {
 	wt.stopRecording();
 }
 
-function startRecordingAudio(wt, channel) {
+function startRecordingAudio(wt, channel, unlimited) {
 	maybeCreateAudioContext();	
 	if (!channel) channel = 0;
 	if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
@@ -210,12 +214,20 @@ function startRecordingAudio(wt, channel) {
 						+ (st.channelCount ? st.channelCount : '?') + ' channel(s) at '
 						+ (st.sampleRate ? st.sampleRate : '?') + 'Hz');
 			}
-			mediaRecorder.start(500);
-			window.setTimeout(function() {
-				if (wt.isRecording()) {
-					stopRecordingAudio(wt);
-				}
-			}, 30000)
+			// No timeslice: one dataavailable, at stop, with the whole take.
+			// Chunking made ondataavailable fire twice a second and each one
+			// decoded everything recorded so far, so a take got quadratically
+			// more expensive the longer it ran.
+			mediaRecorder.start();
+			if (!unlimited) {
+				window.setTimeout(function() {
+					if (wt.isRecording()) {
+						stopRecordingAudio(wt);
+						console.log('vodka: stopped at the 30 second limit. Tag start-recording '
+								+ 'with `unlimited` to record for longer.');
+					}
+				}, RECORDING_LIMIT_MS)
+			}
 		}).catch(function(err) {
 			console.log('couldnt open audio stream');
 		})

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -37,7 +37,6 @@ let thingAuditioning = null;
 let channelPlayers = [];
 let auditioningPlayer = null;
 
-let mediaRecorder = null;
 
 // A guardrail, not a real limit -- so a first recording cannot fill the disk
 // before anyone knows how to stop it. The `unlimited` tag lifts it.
@@ -169,71 +168,139 @@ class LoopingPlayer {
 }
 
 function stopRecordingAudio(wt) {
-	mediaRecorder.stop();
 	wt.stopRecording();
+	if (!recordingRig || recordingRig.wt != wt) return;
+	if (recordingRig.timer) window.clearTimeout(recordingRig.timer);
+	recordingRig.node.port.onmessage = null;
+	recordingRig.source.disconnect();
+	recordingRig.node.disconnect();
+	recordingRig.silence.disconnect();
+	// let go of the microphone, or the browser keeps showing it as in use
+	recordingRig.stream.getTracks().forEach(function(t) { t.stop(); });
+	recordingRig = null;
 }
 
 function startRecordingAudio(wt, channel, unlimited) {
-	maybeCreateAudioContext();	
+	maybeCreateAudioContext();
 	if (!channel) channel = 0;
-	if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
-		navigator.mediaDevices.getUserMedia({
-			// Echo cancellation merges a stereo input to mono and duplicates it, so
-			// it must be off for channelCount: 2 to give two real channels.
-			audio: {
-				echoCancellation: false,
-				noiseSuppression: false,
-				autoGainControl: false,
-				channelCount: 2
-			}
-		}).then(function(stream) {
+	if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+		console.log('vodka: this browser has no audio input');
+		return;
+	}
+	navigator.mediaDevices.getUserMedia({
+		// Echo cancellation merges a stereo input to mono and duplicates it, so it
+		// must be off for channelCount: 2 to give two real channels.
+		audio: {
+			echoCancellation: false,
+			noiseSuppression: false,
+			autoGainControl: false,
+			channelCount: 2
+		}
+	}).then(function(stream) {
+		let track = stream.getAudioTracks()[0];
+		if (track) {
+			let st = track.getSettings();
+			console.log('vodka: recording from "' + track.label + '" -- '
+					+ (st.channelCount ? st.channelCount : '?') + ' channel(s) at '
+					+ (st.sampleRate ? st.sampleRate : '?') + 'Hz');
+		}
+		return maybeLoadRecorderWorklet().then(function() {
+			let source = ctx.createMediaStreamSource(stream);
+			let node = new AudioWorkletNode(ctx, 'vodka-recorder');
+			// A worklet only runs while it is connected to the graph, and this
+			// one listens rather than making a sound, so it goes to a silent
+			// gain node.
+			let silence = ctx.createGain();
+			silence.gain.value = 0;
+			source.connect(node);
+			node.connect(silence);
+			silence.connect(ctx.destination);
+
 			wt.startRecording();
-			mediaRecorder = new MediaRecorder(stream);
-			mediaRecorder.ondataavailable = function(e) {
-				let blob = e.data;
-				wt.addBlob(blob);
-				let allblobs = wt.getBlobsAsOneBlob();
-				allblobs.arrayBuffer().then(function(ab) {
-					ctx.decodeAudioData(ab, function(buffer) {
-						// A wavetable holds one channel, so a stereo input is
-						// recorded one side at a time.
-						if (channel >= buffer.numberOfChannels) {
-							throw constructFatalError(`no input channel ${channel}. Sorry!`);
-						}
-						wt.setRecordedData(buffer.getChannelData(channel));
-					}, function(err) {
-						console.log('oh well');
-					})
-				})
-			}
-			// what the device actually gave us, which is not always what was asked
-			let track = stream.getAudioTracks()[0];
-			if (track) {
-				let st = track.getSettings();
-				console.log('vodka: recording from "' + track.label + '" -- '
-						+ (st.channelCount ? st.channelCount : '?') + ' channel(s) at '
-						+ (st.sampleRate ? st.sampleRate : '?') + 'Hz');
-			}
-			// No timeslice: one dataavailable, at stop, with the whole take.
-			// Chunking made ondataavailable fire twice a second and each one
-			// decoded everything recorded so far, so a take got quadratically
-			// more expensive the longer it ran.
-			mediaRecorder.start();
+			node.port.onmessage = function(e) {
+				if (!wt.isRecording()) return;
+				let batch = e.data;
+				for (let i = 0; i < batch.length; i++) {
+					let blk = batch[i];
+					// a wavetable holds one channel, so a stereo input is
+					// recorded one side at a time
+					wt.appendRecordedData(blk[channel] ? blk[channel] : blk[0]);
+				}
+			};
+
+			recordingRig = { wt: wt, stream: stream, node: node,
+					source: source, silence: silence, timer: null };
 			if (!unlimited) {
-				window.setTimeout(function() {
+				recordingRig.timer = window.setTimeout(function() {
 					if (wt.isRecording()) {
 						stopRecordingAudio(wt);
-						console.log('vodka: stopped at the 30 second limit. Tag start-recording '
-								+ 'with `unlimited` to record for longer.');
+						console.log('vodka: stopped at the 30 second limit. Tag '
+								+ 'start-recording with `unlimited` to record for longer.');
 					}
-				}, RECORDING_LIMIT_MS)
+				}, RECORDING_LIMIT_MS);
 			}
-		}).catch(function(err) {
-			console.log('couldnt open audio stream');
-		})
-	} else {
-		console.log('no user media');
+		});
+	}).catch(function(err) {
+		console.log('vodka: could not open the audio input: '
+				+ err.name + ': ' + err.message
+				+ (err.constraint ? ' (constraint: ' + err.constraint + ')' : ''));
+	});
+}
+
+/*
+RECORDING
+
+Samples are captured with an audio worklet rather than a MediaRecorder. A
+MediaRecorder hands back an encoded blob whose chunks are not independently
+decodable, so showing the waveform as it arrived meant decoding the whole take
+again on every chunk -- work that grew with the length of the recording. A
+worklet hands over raw floats, which is what a wavetable holds anyway, so
+nothing is decoded and the waveform can grow as you record.
+
+The processor is a string loaded from a blob url. A worklet module has to be
+fetched by url, and keeping it in the bundle rather than as a separately served
+file means there is nothing to get out of step.
+*/
+const RECORDER_WORKLET = `
+class VodkaRecorder extends AudioWorkletProcessor {
+	constructor() {
+		super();
+		this.batch = [];
+		this.batched = 0;
 	}
+	process(inputs) {
+		let input = inputs[0];
+		if (input && input.length > 0 && input[0]) {
+			let copy = [];
+			for (let c = 0; c < input.length; c++) {
+				copy.push(new Float32Array(input[c]));
+			}
+			this.batch.push(copy);
+			this.batched += input[0].length;
+			// a block is 128 frames; batching keeps the message rate sane
+			if (this.batched >= 4096) {
+				this.port.postMessage(this.batch);
+				this.batch = [];
+				this.batched = 0;
+			}
+		}
+		return true;
+	}
+}
+registerProcessor('vodka-recorder', VodkaRecorder);
+`;
+
+let recorderWorkletReady = null;
+// what is recording now, so stopRecordingAudio can end it
+let recordingRig = null;
+
+function maybeLoadRecorderWorklet() {
+	if (!recorderWorkletReady) {
+		let url = URL.createObjectURL(
+				new Blob([RECORDER_WORKLET], { type: 'application/javascript' }));
+		recorderWorkletReady = ctx.audioWorklet.addModule(url);
+	}
+	return recorderWorkletReady;
 }
 
 function maybeCreateAudioContext() {


### PR DESCRIPTION
Split out of what was #344. Stacked on #343.

**Decode once.** Every recorded block was being decoded again on each append, so recording got quadratically slower the longer it ran.

**Record through an AudioWorklet** rather than MediaRecorder, so the waveform grows on screen while you record instead of appearing when you stop. Blocks are appended to the wavetable as they arrive.

**`unlimited` lifts the 30 second cap.** Hitting the cap now stops the recording *and* throws, saying to tag the command with `unlimited` if you want more, rather than silently truncating.