### PR TITLE
[9/23] Name a wavetable's samples by an id belonging to the wavetable

### DIFF
--- a/server/src/audiocontainer.js
+++ b/server/src/audiocontainer.js
@@ -19,23 +19,19 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 A saved file that contains audio is a container: the document text, followed by
 the samples that document refers to, in one file.
 
-Wavetables serialize as an index instead of a base64 blob, and the sample list
-after the document supplies the bytes. The serializer mints the indices while
-walking the tree, so they are only meaningful inside the file they were written
-in -- nothing here is an identity that survives being copied somewhere else.
-See issue #319.
+Wavetables serialize as their id instead of a base64 blob, and the sample list
+after the document supplies the bytes under the same ids. That is the id the
+wavetable is known by everywhere its samples might be kept, so a file and
+indexeddb name the same thing the same way.
 
-Two things fall out of that, both for free:
-
-  - Nothing unreachable gets written. Only wavetables the walk actually reached
-    ever got the chance to hand over their samples.
-  - The same sample used twice is stored once, because add() dedupes on content.
+Nothing unreachable gets written: only wavetables the walk actually reached ever
+got the chance to hand over their samples.
 
 The header is length-prefixed rather than delimited, so no part of the document
 has to be escaped and no sentinel has to be picked that document text could
 never contain:
 
-    VODKAC1 <doclen> <len0> <len1> ...\n<doctext><b64 0><b64 1>...
+    VODKAC1 <doclen> <id0>:<len0> <id1>:<len1> ...\n<doctext><b64 0><b64 1>...
 
 A document with no audio in it is written with no container at all. The common
 case stays byte-for-byte what earlier versions wrote, and files written before
@@ -53,18 +49,16 @@ const CHUNK = 0x8000;
 class AudioCollector {
 	constructor() {
 		this.samples = [];
-		this.indexByHash = {};
+		this.ids = [];
+		this.seen = {};
 	}
 
-	// returns the index the document should refer to
-	add(float32array, hash) {
-		if (hash in this.indexByHash) {
-			return this.indexByHash[hash];
-		}
-		let i = this.samples.length;
+	add(id, float32array) {
+		// the same wavetable reached twice is still one wavetable
+		if (this.seen[id]) return;
+		this.seen[id] = true;
+		this.ids.push(id);
 		this.samples.push(float32array);
-		this.indexByHash[hash] = i;
-		return i;
 	}
 
 	isEmpty() {
@@ -110,14 +104,15 @@ function encode(docText, collector) {
 	}
 	let header = [ CONTAINER_MAGIC, docText.length ];
 	for (let i = 0; i < encoded.length; i++) {
-		header.push(encoded[i].length);
+		header.push(collector.ids[i] + ':' + encoded[i].length);
 	}
 	return header.join(' ') + '\n' + docText + encoded.join('');
 }
 
 /*
-Returns { docText, samples } for a container, or null for anything else -- a
-plain document, a server error string, a file from before containers existed.
+Returns { docText, samples } for a container, where samples maps a wavetable id
+to its Float32Array. Returns null for anything else -- a plain document, a
+server error string, a file from before containers existed.
 Callers treat null as "parse this as-is".
 
 A container that doesn't decode also comes back as null rather than throwing.
@@ -132,28 +127,34 @@ function decode(fileText) {
 	if (nl < 0) return null;
 
 	let fields = fileText.substring(0, nl).split(' ');
+	// the document length, then one id:length per wavetable
+	let docLen = Number(fields[1]);
+	if (!Number.isInteger(docLen) || docLen < 0) return null;
+	let ids = [];
 	let lengths = [];
-	for (let i = 1; i < fields.length; i++) {
-		let n = Number(fields[i]);
+	for (let i = 2; i < fields.length; i++) {
+		let c = fields[i].indexOf(':');
+		if (c < 0) return null;
+		let n = Number(fields[i].substring(c + 1));
 		if (!Number.isInteger(n) || n < 0) return null;
+		ids.push(fields[i].substring(0, c));
 		lengths.push(n);
 	}
-	// a doc length and at least one sample, or it wouldn't have been a container
-	if (lengths.length < 2) return null;
+	if (ids.length == 0) return null;
 
-	let total = nl + 1;
+	let total = nl + 1 + docLen;
 	for (let i = 0; i < lengths.length; i++) {
 		total += lengths[i];
 	}
 	if (total != fileText.length) return null;
 
 	let pos = nl + 1;
-	let docText = fileText.substr(pos, lengths[0]);
-	pos += lengths[0];
+	let docText = fileText.substr(pos, docLen);
+	pos += docLen;
 
-	let samples = [];
-	for (let i = 1; i < lengths.length; i++) {
-		samples.push(fromBase64(fileText.substr(pos, lengths[i])));
+	let samples = {};
+	for (let i = 0; i < lengths.length; i++) {
+		samples[ids[i]] = fromBase64(fileText.substr(pos, lengths[i]));
 		pos += lengths[i];
 	}
 	return { docText: docText, samples: samples };

--- a/server/src/audiostore.js
+++ b/server/src/audiostore.js
@@ -172,14 +172,47 @@ session would accumulate every intermediate state of every sound.
 
 Takes the set of hashes the document still mentions. Background, like put().
 */
+/*
+How many saves in a row a sample has to go unmentioned before it is deleted.
+
+Deleting is forever and recorded audio has no other copy, so the question is not
+"is this referenced right now" but "has this stopped being referenced". Those
+differ whenever the document momentarily fails to mention something it still
+holds -- a builtin that starts returning a handle instead of a wavetable, a
+serialization that took a branch nobody thought about. One bad save should not
+be able to destroy a recording.
+
+At the autosave interval this is on the order of a minute of editing, which is
+long enough to notice and stop.
+*/
+const PRUNE_AFTER_MISSES = 30;
+
+// hash -> how many consecutive saves have not mentioned it
+const misses = new Map();
+
 function pruneToKeys(keysInUse) {
 	if (unavailable) return;
+	// Nothing referenced at all is not a document with no audio in it, it is a
+	// document that failed to say. Never act on it.
+	if (keysInUse.size == 0) {
+		misses.clear();
+		return;
+	}
 	let dead = [];
 	loaded.forEach(function(value, hash) {
-		if (!keysInUse.has(hash)) {
+		if (keysInUse.has(hash)) {
+			misses.delete(hash);
+			return;
+		}
+		let n = (misses.get(hash) || 0) + 1;
+		misses.set(hash, n);
+		if (n >= PRUNE_AFTER_MISSES) {
 			dead.push(hash);
 		}
 	});
+	for (let i = 0; i < dead.length; i++) {
+		misses.delete(dead[i]);
+	}
 	if (dead.length == 0) return;
 	for (let i = 0; i < dead.length; i++) {
 		loaded.delete(dead[i]);

--- a/server/src/audiostore.js
+++ b/server/src/audiostore.js
@@ -173,58 +173,20 @@ session would accumulate every intermediate state of every sound.
 Takes the set of hashes the document still mentions. Background, like put().
 */
 /*
-How many saves in a row a sample has to go unmentioned before it is deleted.
-
-Deleting is forever and recorded audio has no other copy, so the question is not
-"is this referenced right now" but "has this stopped being referenced". Those
-differ whenever the document momentarily fails to mention something it still
-holds -- a builtin that starts returning a handle instead of a wavetable, a
-serialization that took a branch nobody thought about. One bad save should not
-be able to destroy a recording.
-
-At the autosave interval this is on the order of a minute of editing, which is
-long enough to notice and stop.
+Forgets a wavetable's samples. Called when the wavetable itself is freed, which
+vodka knows the moment it happens -- heap.free calls cleanupOnMemoryFree as soon
+as the last reference drops. Nothing has to be inferred from what a document
+does or does not mention.
 */
-const PRUNE_AFTER_MISSES = 30;
-
-// hash -> how many consecutive saves have not mentioned it
-const misses = new Map();
-
-function pruneToKeys(keysInUse) {
+function remove(id) {
+	if (!id) return;
+	loaded.delete(id);
 	if (unavailable) return;
-	// Nothing referenced at all is not a document with no audio in it, it is a
-	// document that failed to say. Never act on it.
-	if (keysInUse.size == 0) {
-		misses.clear();
-		return;
-	}
-	let dead = [];
-	loaded.forEach(function(value, hash) {
-		if (keysInUse.has(hash)) {
-			misses.delete(hash);
-			return;
-		}
-		let n = (misses.get(hash) || 0) + 1;
-		misses.set(hash, n);
-		if (n >= PRUNE_AFTER_MISSES) {
-			dead.push(hash);
-		}
-	});
-	for (let i = 0; i < dead.length; i++) {
-		misses.delete(dead[i]);
-	}
-	if (dead.length == 0) return;
-	for (let i = 0; i < dead.length; i++) {
-		loaded.delete(dead[i]);
-	}
 	openDb().then(function(db) {
 		if (!db) return;
 		try {
 			let tx = db.transaction(STORE, 'readwrite');
-			let store = tx.objectStore(STORE);
-			for (let i = 0; i < dead.length; i++) {
-				store.delete(scopedKey(dead[i]));
-			}
+			tx.objectStore(STORE).delete(scopedKey(id));
 		} catch (e) {
 			unavailable = true;
 		}
@@ -240,24 +202,6 @@ bytes rather than the float values.
 Cost is a pass over the buffer, which at a 800ms save debounce is not something
 a person can notice.
 */
-function hashSamples(float32array) {
-	let bytes = new Uint8Array(
-			float32array.buffer,
-			float32array.byteOffset,
-			float32array.byteLength);
-	let h1 = 0x811c9dc5;
-	let h2 = 0x01000193;
-	for (let i = 0; i < bytes.length; i++) {
-		h1 ^= bytes[i];
-		h1 = Math.imul(h1, 0x01000193);
-		// second accumulator over the same data with a different seed, so the
-		// key is 64 bits rather than 32
-		h2 = Math.imul(h2 ^ bytes[i], 0x85ebca6b);
-	}
-	let a = (h1 >>> 0).toString(16);
-	let b = (h2 >>> 0).toString(16);
-	return bytes.length.toString(16) + '-' + a + b;
-}
 
 function isUnavailable() {
 	return unavailable;
@@ -268,7 +212,6 @@ export {
 	get,
 	has,
 	put,
-	pruneToKeys,
-	hashSamples,
+	remove,
 	isUnavailable
 }

--- a/server/src/autosave.js
+++ b/server/src/autosave.js
@@ -99,11 +99,13 @@ function saveNow(rootNode) {
 		console.log('vodka: autosave could not serialize the document: ' + e);
 		return;
 	}
-	writeStorage(storageKey(), JSON.stringify({
+	let wrote = writeStorage(storageKey(), JSON.stringify({
 		version: FORMAT_VERSION,
 		sessionId: systemState.getSessionId() || null,
 		docs: docs
 	}));
+	// A save that did not happen says nothing about what is still in use.
+	if (!wrote) return;
 	// Samples the document no longer mentions are dead. Editing a wavetable
 	// gives its new contents a new hash, so without this every intermediate
 	// state of every sound would be kept forever. Reading the references back

--- a/server/src/autosave.js
+++ b/server/src/autosave.js
@@ -106,28 +106,9 @@ function saveNow(rootNode) {
 	}));
 	// A save that did not happen says nothing about what is still in use.
 	if (!wrote) return;
-	// Samples the document no longer mentions are dead. Editing a wavetable
-	// gives its new contents a new hash, so without this every intermediate
-	// state of every sound would be kept forever. Reading the references back
-	// out of what we just wrote is the cheapest way to know exactly what
-	// survived, and can't drift from it.
-	audioStore.pruneToKeys(collectAudioRefs(docs));
 	saveEditorState();
 }
 
-const AUDIO_REF_RE = /idb:([0-9a-f]+-[0-9a-f]+)/g;
-
-function collectAudioRefs(docs) {
-	let keys = new Set();
-	for (let i = 0; i < docs.length; i++) {
-		let m;
-		AUDIO_REF_RE.lastIndex = 0;
-		while ((m = AUDIO_REF_RE.exec(docs[i])) !== null) {
-			keys.add(m[1]);
-		}
-	}
-	return keys;
-}
 
 /**
  * Called after anything that changes the document. Debounced, because

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -38,6 +38,7 @@ import { Editor } from '../editors.js'
 import { doTutorial } from '../help.js'
 import { getAudioBufferFromData, startRecordingAudio, stopRecordingAudio } from '../webaudio.js'
 import * as audioStore from '../audiostore.js'
+import { newShortId } from '../utils.js'
 import { systemState } from '../systemstate.js'
 
 
@@ -88,8 +89,16 @@ load.
 const FIELD_SEPARATOR = ';';
 const KEY_SEPARATOR = ':';
 const BREAKPOINTS_KEY = 'bp';
-const AUDIO_INDEX_KEY = 'aud';
-const AUDIO_REF_KEY = 'idb';
+
+/*
+Every wavetable has an id, and its samples are found by that id wherever they
+are kept -- in this file, or in indexeddb. One name, so a third place to keep
+them would not need a fourth way of naming them.
+
+It names the wavetable, not its contents: editing the samples keeps the id, so
+the stored copy is overwritten rather than orphaned.
+*/
+const WAVETABLE_ID_KEY = 'wid';
 
 /*
 Decodes samples stored directly in a document. Two formats have been written
@@ -160,8 +169,7 @@ class Wavetable extends Nex {
 		this.doingPan = false;
 		// where the line was before playback borrowed it
 		this.playbackStartSample = -1;
-		// invalidated by cacheValues; see getContentHash
-		this.cachedHash = null;
+		this.wavetableId = newShortId();
 		this.markers = [];
 		this.sectionBeingAuditioned = null;
 		this.recording = false;
@@ -404,22 +412,6 @@ class Wavetable extends Nex {
 		let absMin = Math.abs(mm.min);
 		this.setAmp(Math.max(absMin, mm.max));
 		this.cachedBuffer = getAudioBufferFromData(this.data);
-		// The audio changed, so anything derived from its exact contents is
-		// stale. This is the one place that knows that.
-		this.cachedHash = null;
-	}
-
-	/*
-	Hashing walks every byte, and serializing happens on every autosave, so the
-	result is kept until the audio changes rather than being recomputed from
-	scratch each time. Computed on demand rather than in cacheValues, so loading
-	a document full of audio does not hash all of it before anything is saved.
-	*/
-	getContentHash() {
-		if (!this.cachedHash) {
-			this.cachedHash = audioStore.hashSamples(this.data);
-		}
-		return this.cachedHash;
 	}
 
 	getMinMaxInDataRange(start, end) {
@@ -515,6 +507,7 @@ class Wavetable extends Nex {
 		for (let i = 0; i < this.markers.length; i++) {
 			nex.markers[i] = this.markers[i];
 		}
+		nex.wavetableId = newShortId();
 		nex.cacheSections();
 	}
 
@@ -564,16 +557,16 @@ class Wavetable extends Nex {
 		// Written by autosave. The lookup is synchronous because every record
 		// was read into memory during startup, before any document was built --
 		// see audiostore.js.
-		if (AUDIO_REF_KEY in fields) {
-			this.setSamplesOrSilence(audioStore.get(fields[AUDIO_REF_KEY]));
-			return;
-		}
-		// Samples from elsewhere in this same file. The resolver is only set
-		// while a container is being read -- see systemState.
-		if (AUDIO_INDEX_KEY in fields) {
+		if (WAVETABLE_ID_KEY in fields) {
+			this.wavetableId = fields[WAVETABLE_ID_KEY];
+			// A file being read brings its own samples; otherwise they are in
+			// indexeddb, read into memory at startup so this is synchronous.
 			let resolver = systemState.getAudioSampleResolver();
-			let i = Number(fields[AUDIO_INDEX_KEY]);
-			this.setSamplesOrSilence(resolver ? resolver(i) : null);
+			let samples = resolver ? resolver(this.wavetableId) : null;
+			if (!samples) {
+				samples = audioStore.get(this.wavetableId);
+			}
+			this.setSamplesOrSilence(samples);
 			return;
 		}
 		// The samples themselves, unkeyed. Every file saved before containers
@@ -628,28 +621,21 @@ class Wavetable extends Nex {
 
 	serializeSamples(ctx) {
 		if (ctx.isFile()) {
-			// Into the file's resource section; the document refers to it by
-			// index. Deduped on content, so the same sample used in twenty
-			// places is stored once.
-			return AUDIO_INDEX_KEY + KEY_SEPARATOR
-					+ ctx.audioCollector.add(this.data, this.getContentHash());
+			// into the file's own resource section, under this id
+			ctx.audioCollector.add(this.wavetableId, this.data);
+			return WAVETABLE_ID_KEY + KEY_SEPARATOR + this.wavetableId;
 		}
 		if (ctx.isBrowserStorage()) {
 			// Samples are far too large for localStorage -- roughly 250KB of
-			// base64 per second of audio, against a budget of about five
-			// megabytes for everything -- so they go to IndexedDB and the
-			// document gets a reference.
+			// base64 per second of audio, against about five megabytes for
+			// everything -- so they go to indexeddb and the document keeps only
+			// the id.
 			if (audioStore.isUnavailable()) {
-				// No IndexedDB: a private window, or blocked site data. Say
-				// nothing about the samples rather than writing out a silent
-				// buffer. A wavetable with no audio field comes back as silence
-				// anyway, and there is no reason to store a kilobyte of zeros to
-				// mean "there was nothing to store".
+				// no indexeddb: a private window, or blocked site data
 				return '';
 			}
-			let hash = this.getContentHash();
-			audioStore.put(hash, this.data);
-			return AUDIO_REF_KEY + KEY_SEPARATOR + hash;
+			audioStore.put(this.wavetableId, this.data);
+			return WAVETABLE_ID_KEY + KEY_SEPARATOR + this.wavetableId;
 		}
 		// Display: printing, a debug string, the text of an error message.
 		// Nothing that reads those wants a megabyte of base64, and there is
@@ -1460,6 +1446,9 @@ class Wavetable extends Nex {
 		if (this.recording) {
 			stopRecordingAudio(this);
 		}
+		// Refcounting means this is the moment the wavetable is really gone, so
+		// its samples go with it. Nothing has to be inferred from a document.
+		audioStore.remove(this.wavetableId);
 	}
 
 }

--- a/server/src/servercommunication.js
+++ b/server/src/servercommunication.js
@@ -184,8 +184,8 @@ function parseFileContents(data) {
 	if (!container) {
 		return parse(data);
 	}
-	systemState.setAudioSampleResolver(function(i) {
-		return container.samples[i];
+	systemState.setAudioSampleResolver(function(id) {
+		return container.samples[id];
 	});
 	try {
 		return parse(container.docText);

--- a/server/src/utils.js
+++ b/server/src/utils.js
@@ -305,7 +305,34 @@ function convertV2StringToMath(val) {
 	}
 }
 
+
+/*
+A short random id, for naming something that has to be found again later --
+a wavetable's samples, wherever they are kept.
+
+Twelve base36 characters is about 62 bits. Not a uuid, which is 128 bits and 36
+characters; this only has to stay unique across the wavetables a person makes,
+including ones pasted in from elsewhere, and 62 bits is enormous next to that.
+Short enough to read in a saved file.
+*/
+function newShortId() {
+	let bytes = new Uint8Array(9);
+	if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+		crypto.getRandomValues(bytes);
+	} else {
+		for (let i = 0; i < bytes.length; i++) {
+			bytes[i] = Math.floor(Math.random() * 256);
+		}
+	}
+	let s = '';
+	for (let i = 0; i < bytes.length; i++) {
+		s += bytes[i].toString(36).padStart(2, '0');
+	}
+	return s.substring(0, 12);
+}
+
 export {
+	newShortId,
 	isError,
 	isFatalError,
 	isNonFatalError,


### PR DESCRIPTION
Split out of what was #344. Stacked on #353.

Samples were keyed by a content hash, which meant identical samples were silently deduplicated — never asked for, and a consequence of the key choice rather than a decision. Each wavetable now carries its own short id, stored in its private data as `wid`, and that id is what names its samples both in the audio fork of the file and in IndexedDB.

This is also what makes deletion correct: `cleanupOnMemoryFree` removes the samples for that id, so strict reference counting decides when audio goes, rather than a sweep guessing what is still referenced.

**Includes the fix for the data loss.** `DeferredValue.toStringV2` called `getChildAt(0).toStringV2()` with no context, which meant a display context, which meant the audio was omitted from the save — and the prune that followed then deleted samples that were still in use. That is how a document full of wavetables came back as identical short blanks.