### PR TITLE
[10/23] Count what the undo buffer and the clipboard are holding

### DIFF
--- a/server/src/actions.js
+++ b/server/src/actions.js
@@ -15,13 +15,14 @@ You should have received a copy of the GNU General Public License
 along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { systemState } from './systemstate.js';
+import { systemState } from './systemstate.js'
+import { heap } from './heap.js';
 import { KeyResponseFunctions, DefaultHandlers } from './keyresponsefunctions.js';
 import { manipulator } from './manipulator.js';
 import { constructWarning } from './nex/eerror.js';
 import { scheduleAutosave } from './autosave.js'
 
-const levelsOfUndo = 100;
+const levelsOfUndo = 50;
 
 const actionStack = [];
 
@@ -43,7 +44,58 @@ function retreat(queuePos) {
 	}
 }
 
+/*
+What an action is holding so it can be undone.
+
+Its saved state is on its own fields, as render nodes or as nexes, so they are
+found by looking rather than by every action having to declare them. Children
+are refcounted through their parent, so holding the top of a detached subtree
+holds all of it.
+*/
+function nexesHeldBy(action) {
+	let r = [];
+	for (let k in action) {
+		let v = action[k];
+		if (!v || typeof v != 'object') continue;
+		if (typeof v.getNex == 'function') {
+			let n = v.getNex();
+			if (n) r.push(n);
+		} else if (typeof v.getTypeName == 'function' && v.references !== undefined) {
+			r.push(v);
+		}
+	}
+	return r;
+}
+
+/*
+Something in the undo buffer is still in use, whatever the document says. It has
+to be counted, or the heap frees things undo is still holding -- and being freed
+is no longer only bookkeeping: a wavetable forgets its samples when it goes, so
+an uncounted reference is a wavetable that comes back silent.
+
+Falling off the end of the buffer is therefore the other moment something can
+become free, which is why the slot is released before it is written over. That
+covers a discarded redo tail as well, since those slots are overwritten too.
+*/
+function retainActionNexes(action) {
+	let held = nexesHeldBy(action);
+	for (let i = 0; i < held.length; i++) {
+		heap.addReference(held[i]);
+	}
+	action.heldNexes = held;
+}
+
+function releaseActionNexes(action) {
+	if (!action || !action.heldNexes) return;
+	for (let i = 0; i < action.heldNexes.length; i++) {
+		heap.removeReference(action.heldNexes[i]);
+	}
+	action.heldNexes = null;
+}
+
 function enqueueAndPerformAction(action) {
+	// whatever was in this slot is falling out of the buffer
+	releaseActionNexes(actionStack[nextPosition]);
 	actionStack[nextPosition] = action;
 	if (nextPosition == queueTop) {
 		queueTop = advance(queueTop);
@@ -57,6 +109,8 @@ function enqueueAndPerformAction(action) {
 		nextPosition = advance(nextPosition);
 	}
 	action.doAction();
+	// after doAction, which is where an action captures what it is holding
+	retainActionNexes(action);
 	scheduleAutosave(systemState.getRoot());
 }
 

--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -774,10 +774,13 @@ class Manipulator {
 		} else if (a) {
 			a.setSelected();
 			this._forceInsertionMode(INSERT_BEFORE, a);
-		} else {
+		} else if (p) {
 			p.setSelected();
 			this._forceInsertionMode(INSERT_INSIDE, p);
 		}
+		// No siblings and no parent means it was not in the tree, which undo can
+		// reach by removing something that has already been removed. Nothing
+		// left to select, but nothing to crash over either.
 	}
 
 	removeAndSelectPreviousSiblingIfEmpty(s) {

--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -16,10 +16,31 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 var CLIPBOARD = null;
+
+/*
+The clipboard is holding this, so it is still in use however little the document
+mentions it -- the same as the undo buffer. Refcounting has to know, because
+being freed is not only bookkeeping: a wavetable forgets its samples when it
+goes, and a resource handle ends the loop it names.
+
+Cut is where it shows. It puts the nex on the clipboard and then removes it from
+the tree, which was the last reference, so the thing you were about to paste got
+freed on its way to the clipboard.
+*/
+function setClipboard(nex) {
+	if (CLIPBOARD) {
+		heap.removeReference(CLIPBOARD);
+	}
+	CLIPBOARD = nex;
+	if (CLIPBOARD) {
+		heap.addReference(CLIPBOARD);
+	}
+}
 var CLIPBOARD_INSERTION_MODE = null;
 
 import * as Utils from './utils.js'
 import { systemState } from './systemstate.js'
+import { heap } from './heap.js'
 import { RenderNode } from './rendernode.js' 
 import { Nex } from './nex/nex.js' 
 import { Root } from './nex/root.js' 
@@ -1686,7 +1707,7 @@ class Manipulator {
 
 	// used in keydispatcher.js
 	doCut() {
-		CLIPBOARD = systemState.getGlobalSelectedNode().getNex();
+		setClipboard(systemState.getGlobalSelectedNode().getNex());
 		CLIPBOARD_INSERTION_MODE = systemState.getGlobalSelectedNode().getInsertionMode();
 		if (!isRecordingTest()) {
 			this.copyTextToSystemClipboard(CLIPBOARD.prettyPrint());
@@ -1748,7 +1769,7 @@ class Manipulator {
 	// used in keydispatcher.js
 	doCopy() {
 		try {
-			CLIPBOARD = systemState.getGlobalSelectedNode().getNex().makeCopy();
+			setClipboard(systemState.getGlobalSelectedNode().getNex().makeCopy());
 			CLIPBOARD_INSERTION_MODE = systemState.getGlobalSelectedNode().getInsertionMode();
 			if (!isRecordingTest()) {
 				this.copyTextToSystemClipboard(CLIPBOARD.prettyPrint());

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -235,6 +235,7 @@ class Wavetable extends Nex {
 	at the end.
 	*/
 	appendRecordedData(block) {
+		if (!this.recordedChunks) return;
 		this.recordedChunks.push(block);
 		this.recordedLength += block.length;
 		let joined = new Float32Array(this.recordedLength);


### PR DESCRIPTION
Split out of what was #344. Stacked on #354.

Reference counting did not include the undo buffer or the clipboard, so both could hold a nex the heap had already freed. This was harmless while freeing was pure bookkeeping. It stopped being harmless once a wavetable forgot its samples when freed: an uncounted reference became a wavetable that came back silent, and cutting a running loop stopped it.

- the undo buffer takes a reference on what it holds, and releases it when the slot is overwritten — which covers a discarded redo tail too, since those slots are overwritten as well
- undo is capped at 50 levels, so the buffer cannot hold audio indefinitely
- the clipboard takes a reference, so cutting something does not free it

Known remaining holders are written up in #347. The stuck-audition fix that was in this branch has been dropped — it was a guess and did not work; the bug is #346.