### PR TITLE
[14/14] Wave math builtins, slice-at, and sample conversions

### DIFF
--- a/server/src/builtins/wavemathbuiltins.js
+++ b/server/src/builtins/wavemathbuiltins.js
@@ -1,0 +1,248 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import * as Utils from '../utils.js'
+import { Builtin } from '../nex/builtin.js'
+import { constructWavetable } from '../nex/wavetable.js'
+import { constructInteger } from '../nex/integer.js'
+import { constructFloat } from '../nex/float.js'
+import { UNBOUND } from '../environment.js'
+
+/*
+The wave versions of the math builtins. Each one is the ordinary function
+applied a sample at a time, and each takes numbers or waves anywhere: with no
+wave in sight you get a number back, which is why w+ 3 4 is 7 rather than a
+one sample wave saying 7.
+
+Waves of different lengths loop, so the result is as long as the longest
+argument. That is what makes w* @sound 0.5 a volume change and w* @sound @env
+an envelope, without either being a separate builtin.
+
+Comparisons are signals, not booleans: 1 where the comparison holds and 0 where
+it does not. w< @ramp 0.25 is a pulse a quarter of the way through.
+*/
+
+function isWave(n) {
+	return n.getTypeName() == '-wavetable-';
+}
+
+// The result is as long as the longest wave, and shorter ones repeat inside
+// it. valueAtSample already wraps, so there is nothing to do but ask for a
+// sample past the end.
+function longestOf(nexes) {
+	let dur = 0;
+	for (let i = 0; i < nexes.length; i++) {
+		if (isWave(nexes[i])) {
+			let d = nexes[i].getDuration();
+			if (d > dur) dur = d;
+		}
+	}
+	return dur;
+}
+
+function sampleGetters(nexes) {
+	let r = [];
+	for (let i = 0; i < nexes.length; i++) {
+		let n = nexes[i];
+		if (isWave(n)) {
+			r.push(function(t) { return n.valueAtSample(t); });
+		} else {
+			let v = n.getTypedValue();
+			r.push(function(t) { return v; });
+		}
+	}
+	return r;
+}
+
+/*
+f takes the argument values for one sample and returns the value for that
+sample. Called once when nothing is a wave, and once per sample when something
+is. wantsFloat says whether the number case has to come back as a float even
+when every argument was an integer -- true of everything that can produce a
+fraction, false of the comparisons and of + - and *.
+*/
+function applyOverSamples(nexes, f, wantsFloat) {
+	let dur = longestOf(nexes);
+	let getters = sampleGetters(nexes);
+
+	if (dur == 0) {
+		let vals = [];
+		for (let i = 0; i < getters.length; i++) {
+			vals.push(getters[i](0));
+		}
+		let v = f(vals);
+		let foundFloat = wantsFloat;
+		for (let i = 0; !foundFloat && i < nexes.length; i++) {
+			if (Utils.isFloat(nexes[i])) foundFloat = true;
+		}
+		return foundFloat ? constructFloat(v) : constructInteger(v);
+	}
+
+	let r = constructWavetable(dur);
+	let data = r.getData();
+	let vals = new Array(getters.length);
+	for (let t = 0; t < dur; t++) {
+		for (let i = 0; i < getters.length; i++) {
+			vals[i] = getters[i](t);
+		}
+		data[t] = f(vals);
+	}
+	r.init();
+	return r;
+}
+
+// A variadic wave builtin's arguments arrive in a list. Passing one actual
+// list rather than loose arguments means the list itself, the way gain and mix
+// have always taken it.
+function argsFrom(lst) {
+	if (lst.numChildren() == 1 && lst.getChildAt(0).isNexContainer()) {
+		lst = lst.getChildAt(0);
+	}
+	let r = [];
+	for (let i = 0; i < lst.numChildren(); i++) {
+		r.push(lst.getChildAt(i));
+	}
+	return r;
+}
+
+function createWaveMathBuiltins() {
+
+	// f folds left across the arguments, so w- and w/ subtract and divide in
+	// the order you wrote them.
+	// identity is what you get for no arguments at all, the way + with nothing
+	// to add is 0
+	function variadic(name, f, identity, wantsFloat, docs) {
+		Builtin.createBuiltin(
+			name,
+			[ 'args#%_...' ],
+			function(env, executionEnvironment) {
+				let args = argsFrom(env.lb('args'));
+				if (args.length == 0) return constructInteger(identity);
+				return applyOverSamples(args, function(v) {
+					let acc = v[0];
+					for (let i = 1; i < v.length; i++) {
+						acc = f(acc, v[i]);
+					}
+					return acc;
+				}, wantsFloat);
+			},
+			docs,
+			true /* is infix */
+		);
+	}
+
+	function unary(name, f, docs) {
+		Builtin.createBuiltin(
+			name,
+			[ 'wt#%_' ],
+			function(env, executionEnvironment) {
+				return applyOverSamples([ env.lb('wt') ], function(v) {
+					return f(v[0]);
+				}, true /* a function of one number nearly always gives a fraction */);
+			},
+			docs
+		);
+	}
+
+	function binary(name, f, wantsFloat, docs) {
+		Builtin.createBuiltin(
+			name,
+			[ 'lhs#%_', 'rhs#%_' ],
+			function(env, executionEnvironment) {
+				return applyOverSamples([ env.lb('lhs'), env.lb('rhs') ], function(v) {
+					return f(v[0], v[1]);
+				}, wantsFloat);
+			},
+			docs,
+			true /* is infix */
+		);
+	}
+
+	// 1 where it holds and 0 where it does not, so a comparison is something
+	// you can multiply by.
+	function comparison(name, f, docs) {
+		binary(name, function(a, b) { return f(a, b) ? 1 : 0; }, false, docs);
+	}
+
+	variadic('w+', function(a, b) { return a + b; }, 0, false,
+		'Adds numbers and waves sample by sample. Shorter waves loop. With no waves at all you get a number.');
+	variadic('w*', function(a, b) { return a * b; }, 1, false,
+		'Multiplies numbers and waves sample by sample. Shorter waves loop. This is how you change volume and how you apply an envelope.');
+
+	// one argument negates, the same as the number version
+	Builtin.createBuiltin(
+		'w-',
+		[ 'min#%_', 'sub#%_?' ],
+		function(env, executionEnvironment) {
+			let a = env.lb('min');
+			let b = env.lb('sub');
+			if (b == UNBOUND) {
+				return applyOverSamples([ a ], function(v) { return -v[0]; }, false);
+			}
+			return applyOverSamples([ a, b ], function(v) { return v[0] - v[1]; }, false);
+		},
+		'Subtracts |sub from |min sample by sample, or negates |min if |sub is left out. Shorter waves loop.',
+		true /* is infix */
+	);
+
+	binary('w/', function(a, b) { return a / b; }, true,
+		'Divides |lhs by |rhs sample by sample. Shorter waves loop.');
+
+	comparison('w<', function(a, b) { return a < b; },
+		'1 where |lhs is less than |rhs and 0 where it is not, sample by sample. Turns a ramp into a pulse.');
+	comparison('w>', function(a, b) { return a > b; },
+		'1 where |lhs is greater than |rhs and 0 where it is not, sample by sample.');
+	comparison('w<=', function(a, b) { return a <= b; },
+		'1 where |lhs is less than or equal to |rhs and 0 where it is not, sample by sample.');
+	comparison('w>=', function(a, b) { return a >= b; },
+		'1 where |lhs is greater than or equal to |rhs and 0 where it is not, sample by sample.');
+	comparison('w=', function(a, b) { return a == b; },
+		'1 where |lhs equals |rhs and 0 where it does not, sample by sample.');
+	comparison('w<>', function(a, b) { return a != b; },
+		'1 where |lhs differs from |rhs and 0 where it does not, sample by sample.');
+
+	unary('wsin', Math.sin, 'The sine of every sample, in radians.');
+	unary('wcos', Math.cos, 'The cosine of every sample, in radians.');
+	unary('wtan', Math.tan, 'The tangent of every sample, in radians.');
+	unary('wasin', Math.asin, 'The arcsine of every sample, in radians.');
+	unary('wacos', Math.acos, 'The arccosine of every sample, in radians.');
+	unary('watan', Math.atan, 'The arctangent of every sample, in radians.');
+	unary('wexp', Math.exp, 'e raised to the power of every sample.');
+	unary('wlog-e', Math.log, 'The natural logarithm of every sample.');
+	unary('wlog-10', Math.log10, 'The base 10 logarithm of every sample.');
+	unary('wlog-2', Math.log2, 'The base 2 logarithm of every sample.');
+	unary('wsquare-root', Math.sqrt, 'The square root of every sample.');
+	unary('wfloor', Math.floor, 'Every sample rounded down.');
+	unary('wceiling', Math.ceil, 'Every sample rounded up.');
+	unary('wround', Math.round, 'Every sample rounded to the nearest whole number.');
+
+	binary('watan2', Math.atan2, true,
+		'The arctangent of |lhs over |rhs, sample by sample, in radians.');
+	binary('wpower', Math.pow, true,
+		'|lhs raised to the power of |rhs, sample by sample.');
+	binary('wnth-root', function(a, b) { return Math.pow(a, 1 / b); }, true,
+		'The |rhs-th root of |lhs, sample by sample.');
+	binary('wmodulo', function(a, b) { return a % b; }, false,
+		'The remainder of |lhs divided by |rhs, sample by sample.');
+
+	// These predate the w names and did exactly this, so they stay as the
+	// names people already have in their documents.
+	Builtin.aliasBuiltin('mix', 'w+');
+	Builtin.aliasBuiltin('gain', 'w*');
+}
+
+export { createWaveMathBuiltins }

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -247,6 +247,46 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
+    "wave-to-samples",
+    ["wt_"],
+    function $waveToSamples(env, executionEnvironment) {
+      let wt = env.lb("wt");
+      let data = wt.getData();
+      let r = constructOrg();
+      for (let i = 0; i < data.length; i++) {
+        r.appendChild(constructFloat(data[i]));
+      }
+      return r;
+    },
+    "Turns wt| into an org holding one float for every sample. A second of audio is tens of thousands of samples, so this is meant for short waves."
+  );
+
+  Builtin.createBuiltin(
+    "samples-to-wave",
+    ["samples()"],
+    function $samplesToWave(env, executionEnvironment) {
+      let samples = env.lb("samples");
+      let n = samples.numChildren();
+      if (n == 0) {
+        return constructFatalError("samples-to-wave: nothing to make a wave out of. Sorry!");
+      }
+      let r = constructWavetable(n);
+      let data = r.getData();
+      for (let i = 0; i < n; i++) {
+        let c = samples.getChildAt(i);
+        if (!Utils.isFloat(c) && !Utils.isInteger(c)) {
+          return constructFatalError(
+              "samples-to-wave: item " + (i + 1) + " is not a number. Sorry!");
+        }
+        data[i] = c.getTypedValue();
+      }
+      r.init();
+      return r;
+    },
+    "Turns |samples, an org of numbers, into a wavetable one sample long for each of them. The reverse of wave-to-samples."
+  );
+
+  Builtin.createBuiltin(
     "wavefold",
     ["wt_"],
     function $reverse(env, executionEnvironment) {
@@ -1329,6 +1369,71 @@ function createWavetableBuiltins() {
       return constructInteger(Math.round(ms));
     },
     "Returns the length of |len in whole milliseconds, rounded. |len takes a timebase tag like any other length, so this is how a length in beats becomes a number that something outside the audio system can use."
+  );
+
+  /*
+  A slice point can be tagged the way any other length can, and additionally
+  with of-total, which reads it as a fraction of this particular wave: 0.5
+  of-total is halfway along whatever you passed in. A tag on the list applies
+  to every point in it, so you do not have to tag them one at a time.
+  */
+  function hasTagNamed(nex, name) {
+    for (let i = 0; i < nex.numTags(); i++) {
+      if (nex.getTag(i).getTagString() == name) return true;
+    }
+    return false;
+  }
+
+  function slicePointToSamples(point, list, total) {
+    if (hasTagNamed(point, "of-total") || (list && hasTagNamed(list, "of-total"))) {
+      return Math.round(point.getTypedValue() * total);
+    }
+    let timebase = null;
+    if (point.numTags() > 0) {
+      timebase = nexToTimebase(point);
+    } else if (list && list.numTags() > 0) {
+      timebase = nexToTimebase(list);
+    }
+    return convertTimeToSamples(point, timebase);
+  }
+
+  Builtin.createBuiltin(
+    "slice-at",
+    ["wt_", "points#%()"],
+    function $sliceAt(env, executionEnvironment) {
+      let wt = env.lb("wt");
+      let points = env.lb("points");
+      let total = wt.getDuration();
+
+      let list = Utils.isNexContainer(points) ? points : null;
+      let each = list ? [] : [points];
+      for (let i = 0; list && i < list.numChildren(); i++) {
+        each.push(list.getChildAt(i));
+      }
+
+      let marks = [];
+      for (let i = 0; i < each.length; i++) {
+        let at = slicePointToSamples(each[i], list, total);
+        // the same range the editor enforces: a slice at either end would make
+        // an empty section
+        if (!(at >= 1 && at <= total - 1)) {
+          return constructFatalError(
+              "slice-at: slice point " + at + " is not inside the wave. Sorry!");
+        }
+        marks.push(at);
+      }
+
+      let r = wt.makeCopy();
+      for (let i = 0; i < marks.length; i++) {
+        if (r.markers.indexOf(marks[i]) == -1) {
+          r.markers.push(marks[i]);
+        }
+      }
+      r.markers.sort(function(a, b) { return a - b; });
+      r.cacheSections();
+      return r;
+    },
+    "Returns a copy of wt| with breakpoints at |points, the same breakpoints you get by pressing v while editing a wave. |points is one number or a list of them, and n of them give n+1 slices. They are lengths, so they can be tagged with a timebase, and additionally with of-total to read them as a fraction of this wave -- 0.5 of-total is halfway along. A tag on the list applies to every point in it."
   );
 
   Builtin.createBuiltin(

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -980,47 +980,6 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
-    "gain",
-    ["wtlst#%_..."],
-    function $gain(env, executionEnvironment) {
-      let wtlst = env.lb("wtlst");
-
-      // if the first arg to wtlst is a list instead of a wt, use it
-      if (wtlst.numChildren() == 1 && wtlst.getChildAt(0).isNexContainer()) {
-        wtlst = wtlst.getChildAt(0);
-      }
-
-      let waves = [];
-
-      let dur = 0;
-      for (let i = 0; i < wtlst.numChildren(); i++) {
-        let c = wtlst.getChildAt(i);
-        if (!(c.getTypeName() == "-wavetable-")) {
-          c = getConstantSignalFromValue(c.getTypedValue());
-        }
-        let d = c.getDuration();
-        if (d > dur) {
-          dur = d;
-        }
-        waves.push(c);
-      }
-      let r = constructWavetable(dur);
-      let data = r.getData();
-
-      for (let i = 0; i < dur; i++) {
-        let v = 1;
-        for (let j = 0; j < waves.length; j++) {
-          v *= waves[j].valueAtSample(i);
-        }
-        data[i] = v;
-      }
-      r.init();
-      return r;
-    },
-    "Multiplies together all the passed in numbers or waves"
-  );
-
-  Builtin.createBuiltin(
     "clipad",
     ["wt_", "len#%"],
     function $sizeto(env, executionEnvironment) {
@@ -1209,47 +1168,6 @@ function createWavetableBuiltins() {
       return constructWavetable(dur);
     },
     "Creates an empty wavetable (silence) with a duration of the requested number of samples. Timebase tag (nn, secs, hz, b, samps) is on |len."
-  );
-
-  Builtin.createBuiltin(
-    "mix",
-    ["wtlst#%_..."],
-    function $mix(env, executionEnvironment) {
-      let wtlst = env.lb("wtlst");
-
-      // if the first arg to wtlst is a list instead of a wt, use it
-      if (wtlst.numChildren() == 1 && wtlst.getChildAt(0).isNexContainer()) {
-        wtlst = wtlst.getChildAt(0);
-      }
-
-      let waves = [];
-
-      let dur = 0;
-      for (let i = 0; i < wtlst.numChildren(); i++) {
-        let c = wtlst.getChildAt(i);
-        if (!(c.getTypeName() == "-wavetable-")) {
-          c = getConstantSignalFromValue(c.getTypedValue());
-        }
-        let d = c.getDuration();
-        if (d > dur) {
-          dur = d;
-        }
-        waves.push(c);
-      }
-
-      let r = constructWavetable(dur);
-      let data = r.getData();
-      for (let i = 0; i < dur; i++) {
-        let v = 0;
-        for (let j = 0; j < waves.length; j++) {
-          v += waves[j].valueAtSample(i);
-        }
-        data[i] = v;
-      }
-      r.init();
-      return r;
-    },
-    "Mixes together all the wavetables passed in"
   );
 
   Builtin.createBuiltin(

--- a/server/src/vodka.js
+++ b/server/src/vodka.js
@@ -43,6 +43,7 @@ import { createTagBuiltins } from './builtins/tagbuiltins.js'
 import { createTestBuiltins } from './builtins/testbuiltins.js'
 import { createTypeConversionBuiltins } from './builtins/typeconversions.js'
 import { createWavetableBuiltins } from './builtins/wavetablebuiltins.js'
+import { createWaveMathBuiltins } from './builtins/wavemathbuiltins.js'
 import { createMidiBuiltins } from './builtins/midibuiltins.js'
 import { loadAndRun } from './servercommunication.js'
 import { RenderNode } from './rendernode.js'
@@ -150,6 +151,7 @@ function createBuiltins() {
 	setAPIDocCategory('File Builtins'); createFileBuiltins();
 	setAPIDocCategory('String Builtins'); createStringBuiltins();
 	setAPIDocCategory('Wavetable Builtins'); createWavetableBuiltins();
+	setAPIDocCategory('Wave Math Builtins'); createWaveMathBuiltins();
 	setAPIDocCategory('Midi Builtins'); createMidiBuiltins();
 	setAPIDocCategory('Surface Builtins'); createSurfaceBuiltins();
 	setAPIDocCategory('Make Builtins'); createMakeBuiltins();


### PR DESCRIPTION
Stacked on #351.

**Wave math.** Every math builtin now has a wave counterpart: `w+ w- w* w/`, the comparisons `w< w> w<= w>= w= w<>`, and `wsin wcos wtan wasin wacos watan watan2 wexp wlog-e wlog-10 wlog-2 wsquare-root wnth-root wpower wmodulo wfloor wceiling wround`.

Each takes numbers or waves in any position. With no wave among the arguments you get a number back, so `w+ 3 4` is 7 rather than a one-sample wave saying 7. Waves of different lengths loop, so the result is as long as the longest — which is what makes `w* @sound 0.5` a volume change and `w* @sound @env` an envelope without either being its own builtin.

Comparisons are signals rather than booleans: 1 where it holds, 0 where it does not. `w< @ramp 0.25` is a pulse a quarter of the way through, and the result is something you can multiply by.

Each wave builtin takes the arity of the number builtin it mirrors — `w+` and `w*` variadic, `w-` negating when given one argument, `w/` binary — so they behave the way the number versions already taught you.

**`gain` and `mix` are now aliases** of `w*` and `w+`, which is what they already were over numbers and waves. One behaviour change: `gain 3 4` used to return a one-sample wavetable and now returns the number 12. Calls with a wave in them are unaffected, so `communique` — the only thing in the repo using them — still works.

**`slice-at`** puts breakpoints in a wave from code: the same ones you get by pressing `v` in the editor, and what `split` already slices on. Takes one number or a list; n of them give n+1 sections. Points are lengths so they take a timebase tag, and additionally `of-total`, reading the number as a fraction of this wave — `0.5 of-total` is halfway along. A tag on the list applies to every point in it. Out-of-range points are an error rather than a silently dropped mark. Returns a copy.

**`wave-to-samples` / `samples-to-wave`** convert between a wave and an org of floats, one per sample.

I checked the sample math numerically against stubbed waves before committing — the number/wave split, looping of shorter waves, result length, and the ramp-to-pulse case. Not run inside vodka; the test suite is yours.

`wabs` is deliberately absent: there is no `abs` among the number builtins to mirror. Say the word and I will add both.