### PR TITLE
[16/23] A clip plays for as long as something owns it

### DIFF
--- a/server/src/actions.js
+++ b/server/src/actions.js
@@ -21,7 +21,6 @@ import { KeyResponseFunctions, DefaultHandlers } from './keyresponsefunctions.js
 import { manipulator } from './manipulator.js';
 import { constructWarning } from './nex/eerror.js';
 import { scheduleAutosave } from './autosave.js'
-import * as Utils from './utils.js'
 
 const levelsOfUndo = 50;
 
@@ -69,10 +68,14 @@ function nexesHeldBy(action) {
 }
 
 /*
-Something in the undo buffer is still in use, whatever the document says. It has
-to be counted, or the heap frees things undo is still holding -- and being freed
-is no longer only bookkeeping: a wavetable forgets its samples when it goes, so
-an uncounted reference is a wavetable that comes back silent.
+Something in the undo buffer has to be counted, or the heap frees what undo is
+still holding -- and being freed is no longer only bookkeeping: a wavetable
+forgets its samples when it goes, so an uncounted reference is a wavetable that
+comes back silent.
+
+It is counted separately from real references, because holding what you deleted
+is not the same as using it. Anything asking whether a nex is still wanted has
+to be told no while undo is still holding it: see heap.addUndoReference.
 
 Falling off the end of the buffer is therefore the other moment something can
 become free, which is why the slot is released before it is written over. That
@@ -81,7 +84,7 @@ covers a discarded redo tail as well, since those slots are overwritten too.
 function retainActionNexes(action) {
 	let held = nexesHeldBy(action);
 	for (let i = 0; i < held.length; i++) {
-		heap.addReference(held[i]);
+		heap.addUndoReference(held[i]);
 	}
 	action.heldNexes = held;
 }
@@ -89,7 +92,7 @@ function retainActionNexes(action) {
 function releaseActionNexes(action) {
 	if (!action || !action.heldNexes) return;
 	for (let i = 0; i < action.heldNexes.length; i++) {
-		heap.removeReference(action.heldNexes[i]);
+		heap.removeUndoReference(action.heldNexes[i]);
 	}
 	action.heldNexes = null;
 }
@@ -424,22 +427,6 @@ class TriviallyUndoableKeyResponseFunctionAction extends Action {
 }
 
 
-/*
-Deleting is something you did; being freed is bookkeeping, and undo defers that
-by up to fifty more deletions. Anything that has to react the moment it leaves
-the document -- a clip, which has to stop making noise -- is told here rather
-than waiting for the heap to get round to it.
-*/
-function notifyDeletedFromDocument(nex) {
-	if (!nex) return;
-	if (nex.onDeletedFromDocument) nex.onDeletedFromDocument();
-	if (Utils.isNexContainer(nex)) {
-		for (let i = 0; i < nex.numChildren(); i++) {
-			notifyDeletedFromDocument(nex.getChildAt(i));
-		}
-	}
-}
-
 class DeleteNexAction extends Action {
 	constructor(actionName) {
 		super(actionName);
@@ -455,7 +442,6 @@ class DeleteNexAction extends Action {
 		this.index = this.parentOfNodeWeAreDeleting.getIndexOfChild(this.savedNodeToRestore);
 		this.savedInsertionMode = this.savedNodeToRestore.getInsertionMode();
 		KeyResponseFunctions[this.actionName](systemState.getGlobalSelectedNode());
-		notifyDeletedFromDocument(this.savedNodeToRestore.getNex());
 	}
 
 	undoAction() {

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -21,7 +21,7 @@ import { getMidiPorts, openMidiPort, isPortOpen, addMidiSequence, replaceMidiSeq
 import { convertTimeToSamples, nexToTimebase, getSampleRate } from '../wavetablefunctions.js'
 import { constructClip } from '../nex/clip.js'
 import * as Utils from '../utils.js'
-import { endLoops } from '../webaudio.js'
+import { endLoops, clipStartedPlaying } from '../webaudio.js'
 import { UNBOUND } from '../environment.js'
 import { constructOrg } from '../nex/org.js'; 
 import { constructDeferredValue } from '../nex/deferredvalue.js'; 
@@ -221,11 +221,14 @@ function createMidiBuiltins() {
 					return constructFatalError('loop-midi: that loop already ended. Sorry!');
 				}
 				clip.setIds(ids, what);
+				clipStartedPlaying(clip, ids);
 				return clip;
 			}
 
 			let id = addMidiSequence(port.id, events, lengthSeconds);
-			return constructClip('midi loop', what, [ id ], endLoops);
+			let newclip = constructClip('midi loop', what, [ id ], endLoops);
+			clipStartedPlaying(newclip, [ id ]);
+			return newclip;
 		},
 		'Plays a list of midi notes in a loop on |port, joining the global cycle at its next boundary. Each note is what send-midi-note takes, with a float tagged time saying where in the sequence it falls. A bare number at the end of the list is the gap before the sequence repeats. Returns a clip, which ends the loop when it is deleted, or at the next boundary if passed to end-seq. Passing that clip back in |clip replaces what it is playing rather than starting a second loop.'
 	);

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -47,7 +47,7 @@ import {
   getSampleRate,
   getConstantSignalFromValue,
 } from "../wavetablefunctions.js";
-import { loopPlay, oneshotPlay, abortPlayback, endLoops } from "../webaudio.js";
+import { loopPlay, oneshotPlay, abortPlayback, endLoops, clipStartedPlaying } from "../webaudio.js";
 import { constructClip } from "../nex/clip.js";
 import { Tag } from "../tag.js";
 import { ERROR_TYPE_INFO } from "../nex/eerror.js";
@@ -127,7 +127,7 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
-    "loop-play",
+    "play",
     ["wt_", "channelsorclip?"],
     function $loopPlay(env, executionEnvironment) {
       let wt = env.lb("wt");
@@ -173,12 +173,19 @@ function createWavetableBuiltins() {
           "channel" + (channelnumbers.length == 1 ? " " : "s ") + channelnumbers.join(", ");
       if (clip) {
         clip.setIds(ids, what);
-        return clip;
+      } else {
+        clip = constructClip("audio loop", what, ids, endLoops, channelnumbers);
       }
-      return constructClip("audio loop", what, ids, endLoops, channelnumbers);
+      // the audio system owns it while it plays, and how long that lasts is
+      // decided by whether anything else owns it too
+      clipStartedPlaying(clip, ids);
+      return clip;
     },
-    "Starts playing wt| at the next measure start, and returns a clip naming the loop. |channelsorclip is either the channels to play on, or a clip returned by an earlier loop-play -- given a clip, the loop it names is replaced at the next measure start, staying on the channels it is already on, and you get the same clip back. If it is not provided, the sound is played on the first 2 channels. If it and/or |wt are lists, Vodka will do its best to match up sounds with channels."
+    "Starts playing wt| at the next measure start, and returns a clip naming it. It plays for as long as something holds that clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |channelsorclip is either the channels to play on, or a clip returned by an earlier loop-play -- given a clip, the loop it names is replaced at the next measure start, staying on the channels it is already on, and you get the same clip back. If it is not provided, the sound is played on the first 2 channels. If it and/or |wt are lists, Vodka will do its best to match up sounds with channels."
   );
+
+  // what it was called before it could do both
+  Builtin.aliasBuiltin("loop-play", "play");
 
   Builtin.createBuiltin(
     "start-recording",

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -41,13 +41,15 @@ import {
   setBpm,
   getBpm,
   nexToTimebase,
+  timebaseFromTags,
+  convertSamplesToTimebase,
   getReferenceFrequency,
   setDefaultTimebase,
   getDefaultTimebase,
   getSampleRate,
   getConstantSignalFromValue,
 } from "../wavetablefunctions.js";
-import { loopPlay, oneshotPlay, abortPlayback, endLoops, clipStartedPlaying } from "../webaudio.js";
+import { loopPlay, abortPlayback, endLoops, clipStartedPlaying, pauseLoops } from "../webaudio.js";
 import { constructClip } from "../nex/clip.js";
 import { Tag } from "../tag.js";
 import { ERROR_TYPE_INFO } from "../nex/eerror.js";
@@ -78,53 +80,34 @@ function createWavetableBuiltins() {
     "Returns the default timebase."
   );
 
-  Builtin.createBuiltin(
-    "oneshot-play",
-    ["wt_", "channels#()?"],
-    function $oneshotPlay(env, executionEnvironment) {
-      let wt = env.lb("wt");
-      let channels = env.lb("channels");
-
-      let buffers = [];
-      if (Utils.isNexContainer(wt)) {
-        for (let i = 0; i < wt.numChildren(); i++) {
-          buffers.push(wt.getChildAt(i).getCachedBuffer());
+  /*
+  Pausing is the only way left to silence a clip without waiting for the pass
+  it is in to finish, and it is not the end of anything: the loop keeps its
+  place in the cycle, so resuming brings it back in phase rather than starting
+  a bar of its own. If you did not want it at all you would delete it.
+  */
+  function pauseOrResume(name, paused) {
+    Builtin.createBuiltin(
+      name,
+      ["clip"],
+      function (env, executionEnvironment) {
+        let clip = env.lb("clip");
+        if (!Utils.isClip(clip)) {
+          return constructFatalError(name + ": not a clip. Sorry!");
         }
-      } else {
-        buffers.push(wt.getCachedBuffer());
-      }
-
-      let channelnumbers = [0, 1];
-      if (channels != UNBOUND) {
-        channelnumbers = [];
-        if (Utils.isNexContainer(channels)) {
-          for (let i = 0; i < channels.numChildren(); i++) {
-            channelnumbers.push(channels.getChildAt(i).getTypedValue());
-          }
-        } else {
-          channelnumbers.push(channels.getTypedValue());
+        if (!pauseLoops(clip.getIds(), paused)) {
+          return constructFatalError(name + ": that clip already stopped. Sorry!");
         }
-      }
+        return clip;
+      },
+      paused
+          ? "Silences |clip straight away, keeping its place in the cycle so that resume brings it back in time. Deleting a clip instead lets it finish the pass it is in."
+          : "Starts |clip playing again after pause, at the next measure start and in phase with everything else."
+    );
+  }
 
-      oneshotPlay(buffers, channelnumbers);
-      return wt;
-    },
-    "Plays |wt immediately on the given channel. If |channel is not provided, the sound is played on the first 2 channels. If |channel and/or |wt are lists, Vodka will do its best to match up sounds with channels."
-  );
-
-  Builtin.createBuiltin(
-    "end-seq",
-    ["clip"],
-    function $endSeq(env, executionEnvironment) {
-      let clip = env.lb("clip");
-      if (!Utils.isClip(clip)) {
-        return constructFatalError("end-seq: not a clip. Sorry!");
-      }
-      clip.end(true /* at the end of the cycle, not now */);
-      return clip;
-    },
-    "Ends |clip at the end of the current cycle, so it finishes what it is playing rather than being cut off. Deleting a clip ends it immediately instead."
-  );
+  pauseOrResume("pause", true);
+  pauseOrResume("resume", false);
 
   Builtin.createBuiltin(
     "play",
@@ -963,7 +946,7 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
-    "clipad",
+    "fit to",
     ["wt_", "len#%"],
     function $sizeto(env, executionEnvironment) {
       let len = env.lb("len");
@@ -988,6 +971,9 @@ function createWavetableBuiltins() {
     },
     "Clips the length of the wavetable, or pads the end of it with silence, depending on whether the passed-in length is greater or less than the length of the wavetable. Timebase tag (nn, secs, hz, b, samps) is on |len."
   );
+
+  // short enough to type mid-set
+  Builtin.aliasBuiltin("f", "fit to");
 
   Builtin.createBuiltin(
     "remove-from-start",
@@ -1127,12 +1113,16 @@ function createWavetableBuiltins() {
   Builtin.createBuiltin(
     "duration",
     ["wt_"],
-    function $duration(env, executionEnvironment) {
+    function $duration(env, executionEnvironment, commandTags) {
       let wt = env.lb("wt");
-      let val = wt.getDuration();
-      return constructInteger(val);
+      let samples = wt.getDuration();
+      let timebase = timebaseFromTags(commandTags);
+      if (!timebase || timebase == "SAMPLES") {
+        return constructInteger(samples);
+      }
+      return constructFloat(convertSamplesToTimebase(timebase, samples));
     },
-    "Gets the duration of a signal in samples"
+    "How long wt| is, in samples. Tag the command with a timebase (nn, secs, hz, b, samps) to get it in that instead."
   );
 
   Builtin.createBuiltin(
@@ -1376,7 +1366,34 @@ function createWavetableBuiltins() {
       r.cacheSections();
       return r;
     },
-    "Returns a copy of wt| with breakpoints at |points, the same breakpoints you get by pressing v while editing a wave. |points is one number or a list of them, and n of them give n+1 slices. They are lengths, so they can be tagged with a timebase, and additionally with of-total to read them as a fraction of this wave -- 0.5 of-total is halfway along. A tag on the list applies to every point in it."
+    "Returns a copy of wt| with split points at |points, the same ones you get by pressing v while editing a wave. |points is one number or a list of them, and n of them give n+1 slices. They are lengths, so they can be tagged with a timebase, and additionally with of-total to read them as a fraction of this wave -- 0.5 of-total is halfway along. A tag on the list applies to every point in it."
+  );
+
+  Builtin.createBuiltin(
+    "split-points-of",
+    ["wt_"],
+    function $splitPointsOf(env, executionEnvironment, commandTags) {
+      let wt = env.lb("wt");
+      let total = wt.getDuration();
+      let ofTotal = false;
+      for (let i = 0; commandTags && i < commandTags.length; i++) {
+        if (commandTags[i].getTagString() == "of-total") ofTotal = true;
+      }
+      let timebase = timebaseFromTags(commandTags);
+      let r = constructOrg();
+      for (let i = 0; i < wt.markers.length; i++) {
+        let at = wt.markers[i];
+        if (ofTotal) {
+          r.appendChild(constructFloat(total == 0 ? 0 : at / total));
+        } else if (!timebase || timebase == "SAMPLES") {
+          r.appendChild(constructInteger(at));
+        } else {
+          r.appendChild(constructFloat(convertSamplesToTimebase(timebase, at)));
+        }
+      }
+      return r;
+    },
+    "The split points in wt|, as an org of sample offsets. Tag the command with a timebase (nn, secs, hz, b, samps) to get them in that, or with of-total to get each one as a fraction of the whole wave."
   );
 
   Builtin.createBuiltin(

--- a/server/src/heap.js
+++ b/server/src/heap.js
@@ -107,8 +107,38 @@ class Heap {
     }
   }
 
+  /*
+  Undo is counted apart from everything else. It holds what you deleted so that
+  undoing gets it back intact -- a wavetable that came back silent would be no
+  use -- but it is not an owner in the sense anything else means by the word.
+  Nothing is using a deleted nex, and code that asks "does anyone still want
+  this" has to be able to get the answer no while undo is still holding it.
+
+  A clip is why this matters: deleting one has to stop it, and if undo counted
+  as ownership then a deleted clip would go on playing until it fell off the
+  end of the buffer fifty deletions later.
+
+  Being freed still waits for both to reach zero, which is the whole point of
+  undo holding it in the first place.
+  */
+  addUndoReference(obj) {
+    obj.undoReferences++;
+  }
+
+  removeUndoReference(obj) {
+    if (obj.undoReferences == 0) {
+      throw new Error(
+        "Tried to remove an undo reference when the number of undo references was zero."
+      );
+    }
+    obj.undoReferences--;
+    if (obj.undoReferences == 0 && obj.references == 0) {
+      this.free(obj);
+    }
+  }
+
   addReference(obj) {
-    if (obj.references == 0 && obj.wasFreed) {
+    if (obj.references == 0 && obj.undoReferences == 0 && obj.wasFreed) {
       console.log(
         "warning: an object had its references temporarily go to zero, " +
           "causing its memory to be freed, but then a reference " +
@@ -133,7 +163,7 @@ class Heap {
       );
     }
     obj.references--;
-    if (obj.references == 0) {
+    if (obj.references == 0 && obj.undoReferences == 0) {
       this.free(obj);
     }
   }

--- a/server/src/nex/clip.js
+++ b/server/src/nex/clip.js
@@ -94,14 +94,13 @@ class Clip extends Nex {
 		return this.ended;
 	}
 
-	// Deleting a clip stops it, with no waiting -- the point of deleting a
-	// thing is that it goes away. This cannot wait for the clip to be freed:
-	// undo holds on to what you deleted, so being freed can be a long way off.
-	onDeletedFromDocument() {
-		this.end(false /* now, not at the cycle boundary */);
-	}
-
-	// and if it is still playing when it finally does go, stop it then
+	/*
+	Deleting a clip does not stop it here. The document lets go of it, which
+	is the whole story: at the next boundary the audio system finds it is the
+	only one left holding it and does not schedule another pass. So a deleted
+	clip finishes what it is playing rather than being cut off, and that is
+	the same rule that makes a thrown-away clip play once.
+	*/
 	cleanupOnMemoryFree() {
 		this.end(false);
 	}

--- a/server/src/nex/nex.js
+++ b/server/src/nex/nex.js
@@ -49,6 +49,8 @@ class Nex {
 		this.firstRenderNode = null;
 		this.rendernodes = [];
 		this.references = 0;
+		// counted apart from references: see heap.addUndoReference
+		this.undoReferences = 0;
 		this.memAllocated = false;
 		this.wasFreed = false;
 

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -65,7 +65,8 @@ The sample references were already this shape, so nothing had to be invented
 for them -- "aud:0" and "idb:<hash>" are just the field that says where the
 samples are. Everything else is metadata alongside it.
 
-  bp   breakpoints, ascending sample offsets
+  bp   split points, ascending sample offsets (the key stays bp,
+       which is what already-saved files say)
   aud  index into this file's own sample list, meaningless outside it
   idb  content hash of the samples in IndexedDB, written by autosave
 
@@ -88,7 +89,7 @@ load.
 */
 const FIELD_SEPARATOR = ';';
 const KEY_SEPARATOR = ':';
-const BREAKPOINTS_KEY = 'bp';
+const SPLIT_POINTS_KEY = 'bp'; // the name on disk, kept so old files still read
 
 /*
 Every wavetable has an id, and its samples are found by that id wherever they
@@ -551,7 +552,7 @@ class Wavetable extends Nex {
 			}
 		}
 		this.deserializeSamples(fields, unkeyed);
-		this.restoreMarkers(fields[BREAKPOINTS_KEY]);
+		this.restoreMarkers(fields[SPLIT_POINTS_KEY]);
 	}
 
 	deserializeSamples(fields, unkeyed) {
@@ -608,7 +609,7 @@ class Wavetable extends Nex {
 	serializePrivateData(ctx) {
 		let fields = [];
 		if (this.markers.length > 0) {
-			fields.push(BREAKPOINTS_KEY + KEY_SEPARATOR + this.markers.join(','));
+			fields.push(SPLIT_POINTS_KEY + KEY_SEPARATOR + this.markers.join(','));
 		}
 		// last, and the only field that may arrive without a key. Empty when
 		// there was nowhere to put the samples, in which case no field is

--- a/server/src/wavetablefunctions.js
+++ b/server/src/wavetablefunctions.js
@@ -89,26 +89,32 @@ midi note's duration is tagged `duration` as well as with its timebase -- and
 which came first should not decide whether the timebase is seen. Anything with
 a single tag behaves exactly as before.
 */
-function nexToTimebase(input) {
-	let type = DEFAULT_TIMEBASE;
-	for (let i = 0; i < input.numTags(); i++) {
-		let t = input.getTag(i).getTagString();
-		if (t == 'note' || t == 'nn') {
-			type = 'NOTE';
-		} else if (t == 'seconds' || t == 'second' || t == 'secs' || t == 'sec') {
-			type = 'SECONDS';
-		} else if (t == 'hz' || t == 'Hz' || t == 'HZ' || t == 'cps') {
-			type = 'HZ';
-		} else if (t == 'b' || t == 'beats' || t == 'beat') {
-			type = 'BEATS';
-		} else if (t == 'samples' || t == 'samps' || t == 'samp') {
-			type = 'SAMPLES';
-		} else {
-			continue;
-		}
-		break;
+// null for a tag that does not name a timebase, so callers can tell a tag they
+// understand from one meant for something else
+function timebaseForTagString(t) {
+	if (t == 'note' || t == 'nn') return 'NOTE';
+	if (t == 'seconds' || t == 'second' || t == 'secs' || t == 'sec') return 'SECONDS';
+	if (t == 'hz' || t == 'Hz' || t == 'HZ' || t == 'cps') return 'HZ';
+	if (t == 'b' || t == 'beats' || t == 'beat') return 'BEATS';
+	if (t == 'samples' || t == 'samps' || t == 'samp') return 'SAMPLES';
+	return null;
+}
+
+// tags on a command rather than on one of its arguments
+function timebaseFromTags(tags) {
+	for (let i = 0; tags && i < tags.length; i++) {
+		let type = timebaseForTagString(tags[i].getTagString());
+		if (type) return type;
 	}
-	return type;
+	return null;
+}
+
+function nexToTimebase(input) {
+	for (let i = 0; i < input.numTags(); i++) {
+		let type = timebaseForTagString(input.getTag(i).getTagString());
+		if (type) return type;
+	}
+	return DEFAULT_TIMEBASE;
 }
 
 function setDefaultTimebase(input) {
@@ -261,6 +267,8 @@ export { getSampleRate,
 		 setBpm,
 		 getBpm,
 		 nexToTimebase,
+		 timebaseForTagString,
+		 timebaseFromTags,
 		 setDefaultTimebase,
 		 setDefaultTimebaseValue,
 		 getDefaultTimebase,

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -17,6 +17,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 import { settings } from './globalappflags.js'
 import { constructFatalError } from './nex/eerror.js'
+import { heap } from './heap.js'
 
 
 /*
@@ -404,9 +405,58 @@ function anyLoopsPlaying() {
 	return false;
 }
 
+/*
+While a clip is playing, the audio system owns it. That is what decides how
+long it plays for: at every boundary each playing clip is asked whether anyone
+else still holds it, and one that nobody else holds has just played its last
+pass. Nothing can stop it, replace it or even name it any more, so there is
+nothing to schedule it for.
+
+That is where the one-shot comes from. Shift-enter throws the clip away, so the
+audio system is its only owner and it plays once. Press enter instead and the
+clip lands in the document, which holds it, so it loops. Delete it and the
+document lets go, and it stops at the end of the pass it is in rather than
+being cut off. None of those are special cases.
+
+A clip is spared on the pass that starts it, since the document has not taken
+hold of it yet when the first cycle is scheduled.
+*/
+let playingClips = [];
+
+function clipStartedPlaying(clip, ids) {
+	for (let i = 0; i < playingClips.length; i++) {
+		if (playingClips[i].clip == clip) {
+			playingClips[i].ids = ids;
+			return;
+		}
+	}
+	heap.addReference(clip);
+	playingClips.push({ clip: clip, ids: ids, passes: 0 });
+}
+
+function releaseClip(i) {
+	let clip = playingClips[i].clip;
+	playingClips.splice(i, 1);
+	heap.removeReference(clip);
+}
+
+function retireUnownedClips() {
+	for (let i = playingClips.length - 1; i >= 0; i--) {
+		let p = playingClips[i];
+		if (p.passes == 0) continue;
+		if (p.clip.references <= 1) {
+			// at the end of this pass, not now -- the pass it is in was
+			// scheduled to run to the boundary and should get there
+			p.clip.end(true);
+			releaseClip(i);
+		}
+	}
+}
+
 // Starts every loop at the boundary and cuts it at the end of the cycle, so a
 // loop shorter than the cycle repeats inside it and is truncated.
 function startCycleAt(startTime) {
+	retireUnownedClips();
 	for (let id in cyclePending) {
 		cycleLoops[id] = cyclePending[id];
 		delete cyclePending[id];
@@ -435,6 +485,9 @@ function startCycleAt(startTime) {
 		node.start(startTime);
 		node.stop(startTime + len);
 		loop.node = node;
+	}
+	for (let i = 0; i < playingClips.length; i++) {
+		playingClips[i].passes++;
 	}
 	let nextBoundary = startTime + len;
 	cycleNextBoundaryTime = nextBoundary;
@@ -538,6 +591,12 @@ function endAllLoops() {
 	for (let id in cycleLoops) ids.push(id);
 	for (let id in cyclePending) ids.push(id);
 	endLoops(ids, false);
+	// nothing is going to reach another boundary, so let go of the clips here
+	// rather than leaving the audio system owning them forever
+	while (playingClips.length > 0) {
+		playingClips[0].clip.end(false);
+		releaseClip(0);
+	}
 	if (cycleTimer) {
 		window.clearTimeout(cycleTimer);
 		cycleTimer = null;
@@ -656,5 +715,5 @@ async function getFileAsBuffer(filepath) {
 }
 
 
-export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, addCycleMember, replaceCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, oneshotPlay, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
+export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, clipStartedPlaying, addCycleMember, replaceCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, oneshotPlay, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
 

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -340,27 +340,6 @@ function checkChannelExists(channel) {
 		throw constructFatalError('Unknown audio channel number. Sorry!');
 	}
 }
-
-function oneshotPlay(bufferList, channelList) {
-	maybeCreateAudioContext();
-	channelList.forEach(checkChannelExists);
-
-	let bufferIndex = 0;
-
-	for (let i = 0; i < channelList.length; i++) {
-		let channel = channelList[i];
-		let buffer = bufferList[bufferIndex];
-
-		if (channelPlayers[channel]) {
-			channelPlayers[channel].abortPlay();
-		}
-		channelPlayers[channel] = new OneshotPlayer(buffer, channel);
-
-		bufferIndex = (bufferIndex + 1) % bufferList.length;
-	}
-}
-
-
 /*
 THE GLOBAL CYCLE
 
@@ -477,9 +456,10 @@ function startCycleAt(startTime) {
 		// A member that brings its own way of starting -- midi does, and
 		// schedules messages rather than making a sound.
 		if (loop.start) {
-			loop.start(startTime, len);
+			if (!loop.paused) loop.start(startTime, len);
 			continue;
 		}
+		if (loop.paused) continue;
 		let node = getSourceFromBuffer(loop.buffer, true);
 		node.connect(channelMergerNode, 0, loop.channel);
 		node.start(startTime);
@@ -565,6 +545,30 @@ function replaceCycleMember(id, member) {
 	if (cycleLoops[id]) cycleLoops[id] = member;
 	if (cyclePending[id]) cyclePending[id] = member;
 	return true;
+}
+
+/*
+A paused loop keeps its place in the cycle and its length, so it is still what
+the cycle is measured against and it comes back in phase rather than starting a
+new bar of its own. It simply is not scheduled while it is paused.
+*/
+function pauseLoops(ids, paused) {
+	let found = false;
+	for (let i = 0; i < ids.length; i++) {
+		let loop = cycleLoops[ids[i]] || cyclePending[ids[i]];
+		if (!loop) continue;
+		found = true;
+		loop.paused = paused;
+		if (paused) {
+			if (loop.stop) loop.stop();
+			if (loop.node) {
+				try { loop.node.stop(); } catch (e) {}
+				loop.node.disconnect();
+				loop.node = null;
+			}
+		}
+	}
+	return found;
 }
 
 function endLoops(ids, atCycleEnd) {
@@ -715,5 +719,5 @@ async function getFileAsBuffer(filepath) {
 }
 
 
-export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, clipStartedPlaying, addCycleMember, replaceCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, oneshotPlay, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
+export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, clipStartedPlaying, pauseLoops, addCycleMember, replaceCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
 


### PR DESCRIPTION
Stacked on #357.

The audio system takes a reference on a clip while it is playing, and at every boundary asks each playing clip whether anything else still holds it. One that nothing else holds has just played its last pass — nothing can stop it, replace it, or name it any more, so there is nothing to schedule it for.

Everything else follows from that, with no special cases:

- **shift-enter throws the clip away**, so the audio system is its only owner and it plays once. That is `oneshot-play`, without a builtin for it — so `oneshot-play` is deleted.
- **enter puts the clip in the document**, which holds it, so it loops.
- **deleting it** means the document lets go, so it finishes the pass it is in rather than being cut off. This is the opposite of before, where deleting stopped it dead and `end-seq` was how you let it finish. `end-seq` is deleted too, since that is now the default.

**`loop-play` is `play`**, since looping is no longer what distinguishes it. Old name kept as an alias.

**Undo gets its own reference count.** Without this the whole thing fails: `DeleteNexAction` holds what you deleted, so a deleted clip's count would never fall and it would play until it fell off the end of the buffer fifty deletions later — the exact bug from earlier in the session. Holding is not using, and a question like "does anything still want this" has to be able to come back no while undo is still hanging on. Freeing still waits for both counts to reach zero, which is the point of undo holding it at all.

**`pause` replaces cancelling.** Silencing a clip without waiting for its pass to finish is the one thing left with no way to say it, and it is not the end of anything: the loop keeps its place in the cycle and its length, so resuming brings it back in phase rather than starting a bar of its own. (Folded into `toggle-playback` in #359.)

Also here: `clipad` → `fit to` with `f` as an alias, `stopRecording` → `stop-recording`, and split points are called split points rather than breakpoints. The key on disk stays `bp` so files already saved still read.

`communique` called `oneshot-play`; it calls `play` now, which does the same thing there because the clip is discarded. The `clipad` test types `f`.

**Goldens for `functions_wavetable_clipad` will need regenerating** — the command renders under a different name now.