### PR TITLE
[17/23] Multiselect by ctrl-shift-click

### DIFF
--- a/server/src/actions.js
+++ b/server/src/actions.js
@@ -427,6 +427,38 @@ class TriviallyUndoableKeyResponseFunctionAction extends Action {
 }
 
 
+/*
+The only click that changes the document, so the only one that has to be an
+action. It is built and enqueued directly rather than coming from the factory,
+which is keyed on the name of a keystroke.
+
+The plan is worked out before the action is made, so a click with no answer
+never becomes an undo entry, and redo can apply the same plan again rather than
+recomputing it from a selection that has since moved.
+*/
+class MultiSelectAction extends Action {
+	constructor(plan) {
+		super('multi-select');
+		this.plan = plan;
+	}
+
+	canUndo() {
+		return true;
+	}
+
+	doAction() {
+		this.previousSelection = systemState.getGlobalSelectedNode();
+		this.org = manipulator.applyMultiSelect(this.plan);
+	}
+
+	undoAction() {
+		manipulator.unapplyMultiSelect(this.plan, this.org);
+		if (this.previousSelection) {
+			this.previousSelection.setSelected();
+		}
+	}
+}
+
 class DeleteNexAction extends Action {
 	constructor(actionName) {
 		super(actionName);
@@ -732,4 +764,4 @@ function actionFactory(actionName, eventName) {
 
 
 
-export { actionFactory, enqueueAndPerformAction, undo, redo }
+export { actionFactory, enqueueAndPerformAction, MultiSelectAction, undo, redo }

--- a/server/src/browsereventresponsefunctions.js
+++ b/server/src/browsereventresponsefunctions.js
@@ -18,6 +18,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 import { eventQueueDispatcher } from './eventqueuedispatcher.js'
 import { systemState } from './systemstate.js'
 import { manipulator } from './manipulator.js'
+import { enqueueAndPerformAction, MultiSelectAction } from './actions.js'
 
 // can return null if user clicks on some other thing
 function getParentNexOfDomElement(elt) {
@@ -33,7 +34,9 @@ function respondToClickEvent(nex, renderNode, atTarget, browserEvent) {
 	if (atTarget && browserEvent.shiftKey
 			&& (browserEvent.ctrlKey || browserEvent.metaKey)) {
 		browserEvent.stopPropagation();
-		if (manipulator.multiSelect(renderNode)) {
+		let plan = manipulator.planMultiSelect(renderNode);
+		if (plan) {
+			enqueueAndPerformAction(new MultiSelectAction(plan));
 			eventQueueDispatcher.enqueueImportantTopLevelRender();
 		}
 		return;

--- a/server/src/browsereventresponsefunctions.js
+++ b/server/src/browsereventresponsefunctions.js
@@ -28,6 +28,16 @@ function getParentNexOfDomElement(elt) {
 }
 
 function respondToClickEvent(nex, renderNode, atTarget, browserEvent) {
+	// ctrl-shift-click, and command-shift-click on a mac, selects whatever
+	// contains both this and what is already selected
+	if (atTarget && browserEvent.shiftKey
+			&& (browserEvent.ctrlKey || browserEvent.metaKey)) {
+		browserEvent.stopPropagation();
+		if (manipulator.multiSelect(renderNode)) {
+			eventQueueDispatcher.enqueueImportantTopLevelRender();
+		}
+		return;
+	}
 	if (nex.extraClickHandler) {
 		nex.extraClickHandler(browserEvent.clientX, browserEvent.clientY);
 		return;

--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -1443,6 +1443,81 @@ class Manipulator {
 		}
 	}
 
+	/*
+	Multiselect without a second selection model. Rather than holding two things
+	selected at once, ctrl-shift-click works out the one nex that contains both
+	of them and selects that -- which is usually a nex that already exists, so
+	nothing is disturbed.
+
+	The exception is when the two are in different top-level nexes, where the
+	only thing enclosing both is the document itself. Selecting the document
+	would be selecting everything, so an enclosure is made instead: a vertical
+	org around those two top-level nexes and everything between them.
+	*/
+	multiSelect(clickedNode) {
+		let a = systemState.getGlobalSelectedNode();
+		let b = clickedNode;
+		if (!a || !b || a == b) return false;
+		let root = systemState.getRoot();
+
+		let aChain = [];
+		for (let n = a; n; n = n.getParent()) aChain.push(n);
+		// the selection is not in the document at all, so there is nothing to
+		// find a common ancestor in
+		if (aChain.indexOf(root) == -1) return false;
+
+		let common = null;
+		for (let n = b; n; n = n.getParent()) {
+			if (aChain.indexOf(n) != -1) {
+				common = n;
+				break;
+			}
+		}
+		if (!common) return false;
+		if (common != root) {
+			common.setSelected();
+			return true;
+		}
+		return this._encloseTopLevelSpan(a, b, root);
+	}
+
+	_topLevelAncestor(node, root) {
+		for (let n = node; n; n = n.getParent()) {
+			if (n.getParent() == root) return n;
+		}
+		return null;
+	}
+
+	_encloseTopLevelSpan(a, b, root) {
+		let r1 = this._topLevelAncestor(a, root);
+		let r2 = this._topLevelAncestor(b, root);
+		if (!r1 || !r2 || r1 == r2) return false;
+
+		let from = Math.min(root.getIndexOfChild(r1), root.getIndexOfChild(r2));
+		let to = Math.max(root.getIndexOfChild(r1), root.getIndexOfChild(r2));
+
+		/*
+		Held across the move, because taking a nex out of the document is the
+		last reference to it letting go: without this the heap would free each
+		one and then have to reallocate it as it went back in.
+		*/
+		let taken = [];
+		for (let i = to; i >= from; i--) {
+			let child = root.getChildAt(i);
+			heap.addReference(child.getNex());
+			taken.unshift(root.removeChildAt(i));
+		}
+
+		let org = new RenderNode(constructOrg());
+		root.insertChildAt(org, from);
+		for (let i = 0; i < taken.length; i++) {
+			org.appendChild(taken[i]);
+			heap.removeReference(taken[i].getNex());
+		}
+		org.setSelected();
+		return true;
+	}
+
 	wrapSelectedInAndSelect(wrapperNode) {
 		let s = this.selected();
 		let p = s.getParent();

--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -1453,18 +1453,22 @@ class Manipulator {
 	only thing enclosing both is the document itself. Selecting the document
 	would be selecting everything, so an enclosure is made instead: a vertical
 	org around those two top-level nexes and everything between them.
+
+	Worked out first and carried out second, so that the click can be an
+	undoable action: nothing happens for a click with no answer, and a plan can
+	be applied again on redo.
 	*/
-	multiSelect(clickedNode) {
+	planMultiSelect(clickedNode) {
 		let a = systemState.getGlobalSelectedNode();
 		let b = clickedNode;
-		if (!a || !b || a == b) return false;
+		if (!a || !b || a == b) return null;
 		let root = systemState.getRoot();
 
 		let aChain = [];
 		for (let n = a; n; n = n.getParent()) aChain.push(n);
 		// the selection is not in the document at all, so there is nothing to
 		// find a common ancestor in
-		if (aChain.indexOf(root) == -1) return false;
+		if (aChain.indexOf(root) == -1) return null;
 
 		let common = null;
 		for (let n = b; n; n = n.getParent()) {
@@ -1473,12 +1477,46 @@ class Manipulator {
 				break;
 			}
 		}
-		if (!common) return false;
+		if (!common) return null;
 		if (common != root) {
-			common.setSelected();
-			return true;
+			return { kind: 'select', node: common };
 		}
-		return this._encloseTopLevelSpan(a, b, root);
+
+		let r1 = this._topLevelAncestor(a, root);
+		let r2 = this._topLevelAncestor(b, root);
+		if (!r1 || !r2 || r1 == r2) return null;
+		let i1 = root.getIndexOfChild(r1);
+		let i2 = root.getIndexOfChild(r2);
+		return {
+			kind: 'enclose',
+			from: Math.min(i1, i2),
+			to: Math.max(i1, i2)
+		};
+	}
+
+	// the org that was made, so undo can find it again
+	applyMultiSelect(plan) {
+		if (plan.kind == 'select') {
+			plan.node.setSelected();
+			return null;
+		}
+		let root = systemState.getRoot();
+		let taken = this._takeChildren(root, plan.from, plan.to);
+		let org = new RenderNode(constructOrg());
+		root.insertChildAt(org, plan.from);
+		this._putChildren(org, taken, 0);
+		org.setSelected();
+		return org;
+	}
+
+	unapplyMultiSelect(plan, org) {
+		if (plan.kind == 'select' || !org) return;
+		let root = systemState.getRoot();
+		let at = root.getIndexOfChild(org);
+		if (at == -1) return;
+		let taken = this._takeChildren(org, 0, org.numChildren() - 1);
+		root.removeChildAt(at);
+		this._putChildren(root, taken, at);
 	}
 
 	_topLevelAncestor(node, root) {
@@ -1488,34 +1526,28 @@ class Manipulator {
 		return null;
 	}
 
-	_encloseTopLevelSpan(a, b, root) {
-		let r1 = this._topLevelAncestor(a, root);
-		let r2 = this._topLevelAncestor(b, root);
-		if (!r1 || !r2 || r1 == r2) return false;
-
-		let from = Math.min(root.getIndexOfChild(r1), root.getIndexOfChild(r2));
-		let to = Math.max(root.getIndexOfChild(r1), root.getIndexOfChild(r2));
-
-		/*
-		Held across the move, because taking a nex out of the document is the
-		last reference to it letting go: without this the heap would free each
-		one and then have to reallocate it as it went back in.
-		*/
+	/*
+	Held across the move, because taking a nex out of the document is the last
+	reference to it letting go: without this the heap would free each one --
+	and a wavetable being freed forgets its samples -- and then have to
+	reallocate it as it went back in.
+	*/
+	_takeChildren(parent, from, to) {
 		let taken = [];
 		for (let i = to; i >= from; i--) {
-			let child = root.getChildAt(i);
+			let child = parent.getChildAt(i);
+			if (!child) continue;
 			heap.addReference(child.getNex());
-			taken.unshift(root.removeChildAt(i));
+			taken.unshift(parent.removeChildAt(i));
 		}
+		return taken;
+	}
 
-		let org = new RenderNode(constructOrg());
-		root.insertChildAt(org, from);
+	_putChildren(parent, taken, at) {
 		for (let i = 0; i < taken.length; i++) {
-			org.appendChild(taken[i]);
+			parent.insertChildAt(taken[i], at + i);
 			heap.removeReference(taken[i].getNex());
 		}
-		org.setSelected();
-		return true;
 	}
 
 	wrapSelectedInAndSelect(wrapperNode) {


### PR DESCRIPTION
Stacked on #358.

Rather than a second selection model that the rest of the editor would have to know about, ctrl-shift-click — command-shift-click on a mac — works out the one nex containing both what you clicked and what was already selected, and selects that. Usually such a nex already exists, so nothing in the document is disturbed.

The exception is two nexes in different top-level nexes, where the only thing enclosing both is the document. Selecting that would be selecting everything, so an enclosure is made instead: a vertical org around those two top-level nexes and everything between them.

**It is undoable.** The plan is worked out before the action is built, so a click with no answer never becomes an undo entry, and redo applies the same plan rather than recomputing from a selection that has since moved. The action is constructed and enqueued directly rather than through `actionFactory`, which is keyed on keystroke names — this is the only click that changes the document, so it is the only one that needs to be an action.

**References are held across the move**, in both directions. Taking a top-level nex out of the document is the last reference to it letting go, so without this the heap would free each one — and a freed wavetable forgets its samples — and reallocate it on the way back in. The heap logs a warning for exactly this.

One consequence of the rule as specified: two nexes inside the same top-level nex always give you an existing ancestor, which may be much larger than you wanted. Two words in different lines of a doc give you the doc.