### PR TITLE
[19/23] Build saw from partials, add trianglewave, alias phasor

### DIFF
--- a/MORE_BUILTINS.md
+++ b/MORE_BUILTINS.md
@@ -14,6 +14,15 @@ hi-hat with the same peak sound wildly different. That matters if you are
 levelling a folder of samples against each other. If you are not doing that, skip
 both.
 
+[js] let's name the builtin "volume" then since that's what it measures, and have
+an alias of 'rms'. But it should not return a single value, since it calculates over
+a window, you can generate a wave that gives you the rms as it changes over the course
+of a wave. We can make the window configurable and/or make it do the whole wave.
+
+# average
+Would it make sense to have a builtin that just computes the average of some set of values?
+Not sure if yes or no.
+
 # peak-of
 again what do you need this for?
 
@@ -22,6 +31,10 @@ one thing it buys you that normalize does not is *asking without changing*: "is
 this clipping" or "is this basically silence" as a condition in code. That only
 becomes useful once you are generating waves programmatically and want to branch
 on the result. Low priority.
+
+[js] I see, so code something like calling peak-of and if it's > some number, do something.
+Again, it should be windowed like RMS above so you can see a graph of the peak over
+time.
 
 # amplitude
 this is the same as an envelope follower, isn't it? what's the difference? Could alias it to envelope-of.
@@ -35,6 +48,8 @@ and alias envelope-of to it if that name reads better to you. Worth noting slew
 already does the smoothing half, so amplitude + slew may already be your envelope
 follower.
 
+[js] makes sense.
+
 # zero-crossings
 what would you use it for?
 
@@ -42,6 +57,9 @@ what would you use it for?
 pitch detector for monophonic material and a rough noisiness measure (noise
 crosses zero far more often than a sine), but both are things you would want
 properly or not at all, and properly means fft.
+
+[js] agree, drop it, however I think a useful and related function might be
+something like "find-nearest-zero-crossing"
 
 # centroid-of
 same question, what for?
@@ -51,6 +69,8 @@ folder of hits and want "the darkest one" or want to arrange them dark to bright
 centroid is the one number that tracks what your ear calls brightness, and it is
 much cheaper than an fft. It is a librarian's tool rather than a sound design
 tool. If your sample handling is by ear and by hand, skip it.
+
+[js] interesting, can we just call it brightness and alias to centroid-of?
 
 # convolve
 The reason I implemented this is basically for reverb. If you have an impulse response you can use this to add fairly realistic reverb. Since vodka doesn't do realtime generation of sounds and everything is a precomputed wavetable, this gets you better results than any algorithm would give you - at least this was my thinking, but maybe I'm wrong.
@@ -65,6 +85,8 @@ Two things convolution cannot do, which is the only argument for having both:
 it cannot change over time (no reverb that opens up as it decays, no modulated
 tail), and it cannot go beyond the length of the impulse you have. If you never
 want either, convolve is genuinely enough.
+
+[js] good points. Maybe we can start with a basic reverb.
 
 # fft-of / inverse-fft
 I can see how this would be helpful, but have to think about what it would return. Ideally all data is stored in waves, even if it's not sound. So bucket intensities could be a wave I guess.
@@ -84,6 +106,11 @@ frequencies are present overall but nothing about when. What you actually want
 for spectral effects is a series of overlapping ffts, which means an org of waves
 rather than a wave. That is the real design question, and it is the same question
 granulate raises.
+
+[js] hmm, would it be better to return an org full of waves where each wave represents a bin and the wave
+shows you a windowed view of how that bin changes over time? What is more useful, more bins or higher windowing
+resolution? With regard to phase, how expensive is it? Because we could just have two functions,
+fft-of and fft-phase-of, so you call the second one if you want it to be invertable.
 
 # filters
 number of poles is orthogonal to whether it's lowpass, highpass, bandpass, etc. I do know that I need more filters but I was thinking of going for the model where you have a builtin that just determines whether it is single or double (or triple?) pole, and then you pass an arg telling it what *type* of filter (low, high, bandpass, notch).
@@ -116,6 +143,11 @@ Comb: yes, separate. It is a delay fed back on itself, so it is closer to your
 delay and feedback builtins than to your filters, and with the wrap tag those now
 compose into one. It might already exist in your toolkit without a new builtin.
 
+[js] I think we should add resonance as native to the builtin, and I now remember
+about allpass. I think we should have a separate allpass builtin since it's used
+for different purposes than the other filter types, as you say. We need comb in order
+to implement flanging, right? Should it be a builtin?
+
 # time-stretch
 yes I definitely want this, doesn't this require granular synthesis to do it?
 
@@ -126,6 +158,8 @@ different rate than the output. Build granulate and time-stretch is a short
 function on top of it. The alternative is a phase vocoder, which needs the fft
 work above and has its own smeary character.
 
+[js] ok great.
+
 # pitch-shift
 I also definitely want this, does this also require granular synthesis?
 
@@ -134,6 +168,8 @@ time-stretch followed by resampling. Stretch to twice the length, play back twic
 as fast, and you get the original length at half the pitch. So resample-by plus
 time-stretch already gives you pitch-shift for free -- you may not need a builtin
 at all, just a function.
+
+[js] eh, it will be easier if there's just a function for it.
 
 # granulate
 Yeah this would be great
@@ -149,6 +185,14 @@ instinct is one wave, with the grain parameters -- size, spacing, jitter,
 position, and a position that can itself be a wave so the playhead can wander --
 and a separate builtin later if you want the grains individually.
 
+[js] I think returning it as one wave just creates a situation where you have to
+keep adding more and more features to the builtin as people ask for things.
+What if it returned an org full of short waves, one for each grain? Yes it's
+potentially a lot of memory but in practice users would not actually view
+all the grains, they would instead call it in a function that then does something
+with the grains. I don't know enough about grains to know what metadata should
+exist. Is this a case for the WASM engine we discussed earlier?
+
 # reverb
 see note above under convolve. I don't know what shroeder-reverb is and I don't know whether I should have this. Maybe these algorithmic reverbs are commoon enough that people are used to the sound and want to hear them
 
@@ -163,6 +207,8 @@ recognise, and an impulse response of a real space cannot give you a shimmering
 80s digital tail. But you can sample those too -- impulse responses of famous
 reverb units are easy to find. Given that, I would say your convolution approach
 covers it and an algorithmic reverb is a nice-to-have.
+
+[js] eh let's implement it and just call it reverb, make it simple for users.
 
 # waveshape
 Can you help me understand how this is a generalization of wavefolding? What's the difference?
@@ -181,6 +227,9 @@ generate, or record -- and you can build the curve using the wave math you just
 got. That is why I think it is the highest-value item on the whole list for a
 system like yours: it turns a category of builtins into one builtin plus your
 existing tools.
+
+[js] I may in fact have implemented waveshaping and called it wavefolding -- take a look
+at the code and let's rename if so.
 
 # bitcrush / sample-reduce
 Great ideas
@@ -207,6 +256,8 @@ circuits do and why overdriven tape and tubes sound warm rather than nasty.
 It is one curve, so if you build waveshape you get it for free and should not
 have it as a builtin.
 
+[js] okay
+
 # trianglewave and pulsewave
 Yeah I guess, although someone can make it out of ramp it's still probably a nice to have, something more inexperienced people will reach for, not realizing they can derive it. Also for triangle I could do what I did for squarewave and create a more hardware-realistic one out of composing partials.
 
@@ -217,6 +268,9 @@ does not.
 Pulsewave I would now skip: w< on a ramp gives you any duty cycle in one
 expression, and it teaches the thing you would want someone to learn. If it turns
 out you reach for it constantly, alias it rather than implement it.
+
+[js] is our existing saw built from partials? If we are going to give people triangle out of partials we should do it
+with saw too. All of them could be built out of ramp if they want the non-partial version.
 
 # impulse
 why?
@@ -233,6 +287,8 @@ you want it depends entirely on whether you want to build up impulse responses
 yourself, given you are relying on convolution for reverb. Trivial to make out of
 samples-to-wave now, so probably not a builtin.
 
+[js] yeah I'm not sure this is something we need
+
 # phasor
 isn't this already what ramp does?
 
@@ -240,3 +296,5 @@ isn't this already what ramp does?
 before suggesting it. The only difference in Max and Pd is that phasor is
 specified by frequency and runs forever while ramp is specified by length, and
 your timebase tags already let you say either. Withdrawn.
+
+[js] okay let's make it an alias for max/msp and pd users.

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -313,7 +313,7 @@ function createWavetableBuiltins() {
       r.init();
       return r;
     },
-    "Reverses wavetable |wt"
+    "Folds any part of |wt that goes outside -1 to 1 back inside, reflecting it off the limit as many times as it takes. Unlike clipping, what goes over is kept rather than flattened, which is what gives folding its sound."
   );
 
   Builtin.createBuiltin(
@@ -591,6 +591,48 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
+    "trianglewave",
+    ["nn#%?"],
+    function $trianglewave(env, executionEnvironment) {
+      let nn = env.lb("nn");
+      if (nn == UNBOUND) {
+        nn = constructInteger(getReferenceFrequency());
+        nn.addTag(
+          newTagOrThrowOOM("hz", "trianglewave wavetable builtin, timebase")
+        );
+        sAttach(nn);
+      }
+
+      let dur = convertTimeToSamples(nn);
+      let r = constructWavetable(dur);
+      let data = r.getData();
+
+      /*
+      Odd harmonics again, like a square, but falling off as 1/k squared rather
+      than 1/k, with every other one inverted. That much steeper fall-off is why
+      a triangle sounds so much softer than a square, and why sixteen partials
+      is already more than you can hear.
+      */
+      let numHarmonics = 16;
+      let freq = (1 / dur) * getSampleRate();
+      for (let i = 0; i < dur; i++) {
+        let omega = 2 * Math.PI * freq;
+        let time = (1 / getSampleRate()) * i;
+
+        let s = 0;
+        for (let k = 1; k <= numHarmonics; k += 2) {
+          let sign = ((k - 1) / 2) % 2 == 0 ? 1 : -1;
+          s += sign * (1 / (k * k)) * Math.sin(k * omega * time);
+        }
+        data[i] = s * (8 / (Math.PI * Math.PI));
+      }
+      r.init();
+      return r;
+    },
+    "Returns a wavetable containing one cycle of a triangle wave, built from its partials so that it does not alias, and running from -1 to 1. Length is given by |nn. Timebase tag (nn, secs, hz, b, samps) is on |nn."
+  );
+
+  Builtin.createBuiltin(
     "sawwave",
     ["nn#%?"],
     function $sawwave(env, executionEnvironment) {
@@ -607,14 +649,29 @@ function createWavetableBuiltins() {
       let r = constructWavetable(dur);
       let data = r.getData();
 
+      /*
+      Built out of partials, the same way squarewave is, rather than as a
+      straight line. A real saw has every harmonic falling off as 1/k, and
+      stopping at sixteen of them is what keeps it from aliasing into a mess at
+      high pitches. The ideal sharp-cornered version is what ramp already is.
+      */
+      let numHarmonics = 16;
+      let freq = (1 / dur) * getSampleRate();
       for (let i = 0; i < dur; i++) {
-        let d = i / dur;
-        data[i] = d;
+        let omega = 2 * Math.PI * freq;
+        let time = (1 / getSampleRate()) * i;
+
+        let s = 0;
+        for (let k = 1; k <= numHarmonics; k++) {
+          let sign = k % 2 == 1 ? 1 : -1;
+          s += sign * (1 / k) * Math.sin(k * omega * time);
+        }
+        data[i] = s * (2 / Math.PI);
       }
       r.init();
       return r;
     },
-    "Returns a wavetable containing one cycle of a saw wave. Length is given by |nn. Timebase tag (nn, secs, hz, b, samps) is on |nn."
+    "Returns a wavetable containing one cycle of a saw wave, built from its partials so that it does not alias, and running from -1 to 1. For the ideal straight-line version use ramp. Length is given by |nn. Timebase tag (nn, secs, hz, b, samps) is on |nn."
   );
 
   Builtin.createBuiltin(
@@ -643,6 +700,13 @@ function createWavetableBuiltins() {
     },
     "Returns a wavetable ramping from one to zero. Length is given by |len. Timebase tag (nn, secs, hz, b, samps) is on |len."
   );
+
+  /*
+  What max and pd call this. Note that theirs counts up and vodka's ramp counts
+  down, so a phasor here is upside down compared to the one those users have in
+  their fingers.
+  */
+  Builtin.aliasBuiltin("phasor", "ramp");
 
   Builtin.createBuiltin(
     "resample-to",


### PR DESCRIPTION
Stacked on #360. First of the new-builtin PRs.

You asked whether the existing saw is built from partials. It is not — `squarewave` sums sixteen odd harmonics, but `sawwave` was `data[i] = i / dur`, a straight line, which is what `ramp` already does. So both saw and triangle are built from partials here and the three oscillators are consistent.

**Verified numerically** before committing:

- triangle peaks at a quarter and three quarters of the way through and crosses zero between them — a real triangle
- saw rises monotonically with a single jump

Two things about the new saw worth knowing:

**It runs -1 to 1 where it used to run 0 to 1.** A band-limited saw is bipolar, and this matches `squarewave`, which is already bipolar. But anything using `sawwave` as a unipolar 0-to-1 envelope will now go negative. `ramp` is the unipolar one.

**Its jump lands in the middle of the wavetable**, not at the end. That falls out of the Fourier series and is a small bonus: a single cycle loops against itself without a click, where the old one jumped at the loop point.

It also overshoots ±1 by about twelve percent right at the jump. That is Gibbs, it is what a band-limited saw is supposed to do, and `normalize` or `wavefold` will deal with it if you do not want it.

**`phasor` is an alias for `ramp`** — but a caveat you should decide on. Max and Pd's phasor counts *up* from 0 to 1; vodka's `ramp` counts *down* from 1 to 0. So a Max user typing `phasor` gets one upside down from the one in their fingers. Options: leave it, reverse `ramp` (breaking), or make `phasor` its own six-line builtin that ascends. I did the alias you asked for and left the other two to you.

Also here: `wavefold`'s docstring said "Reverses wavetable |wt", copy-pasted from `reverse`.

`wavefold` is genuine folding, by the way — it reflects out-of-range values back inside iteratively, which is the triangular transfer function specifically, not a general lookup. So `waveshape` stays a separate builtin rather than a rename.

This PR also carries your `[js]` answers in MORE_BUILTINS.md as their own commit.