### PR TITLE
[21/23] Split the api reference into a base api and a sound api

### DIFF
--- a/server/src/components/api_reference_panel.jsx
+++ b/server/src/components/api_reference_panel.jsx
@@ -84,10 +84,26 @@ const DocItem = ({item}) => {
     );
 };
 
-const ApiReferencePanel = () => {
-    const groups = docs();
+/*
+Making sound and writing code are different jobs, and there are enough builtins
+for each that one list means scrolling past all of one to reach the other.
+*/
+const SOUND_CATEGORIES = [
+    'Wavetable Builtins',
+    'Wave Math Builtins',
+    'Midi Builtins',
+];
+
+function isSound(category) {
+    return SOUND_CATEGORIES.indexOf(category) != -1;
+}
+
+const ApiReferencePanel = ({sound}) => {
+    // an unrecognised category is not sound, so one added later shows up in
+    // the base api rather than in neither
+    const groups = docs().filter((group) => isSound(group.category) == !!sound);
     return (
-        <div className="infopanel" id="fullapireference">
+        <div className="infopanel" id={sound ? 'soundapireference' : 'baseapireference'}>
             <SectionNav groups={groups} />
             {groups.map((group) => (
                 <div key={group.category}>

--- a/server/src/components/app.jsx
+++ b/server/src/components/app.jsx
@@ -16,7 +16,7 @@ import {
 } from '../help';
 
 
-import { WELCOME, QUICK_REFERENCE, ABSTRACT_DATA_TYPES, FULL_API_REFERENCE, START_TUTORIAL, CLOSE_HELP } from './menu_constants.js';
+import { WELCOME, QUICK_REFERENCE, ABSTRACT_DATA_TYPES, BASE_API, SOUND_API, START_TUTORIAL, CLOSE_HELP } from './menu_constants.js';
 
 const MINIMIZED = 0;
 const SHOWING_PANELS = 1;
@@ -27,7 +27,8 @@ const HIDDEN = 3;
 
 const WELCOME_PANEL = 0;
 const BASIC_USAGE_PANEL = 1;
-const API_REFERENCE_PANEL = 2;
+const BASE_API_PANEL = 2;
+const SOUND_API_PANEL = 6;
 const ABSTRACT_DATA_TYPES_PANEL = 3;
 
 function initialUiState() {
@@ -40,7 +41,8 @@ function initialUiState() {
 
 const App = () => {
     let [ uiState, setUiState ] = useState(initialUiState);
-    let [ panel, setPanel ] = useState(WELCOME_PANEL);
+    // opens on the quick reference, since welcome is no longer a tab
+    let [ panel, setPanel ] = useState(BASIC_USAGE_PANEL);
 
     // While the help panel is up, keystrokes belong to the panel, not to the
     // editor underneath it -- otherwise typing scrolls/inserts nexes behind
@@ -65,8 +67,11 @@ const App = () => {
             case ABSTRACT_DATA_TYPES:
                 setPanel(ABSTRACT_DATA_TYPES_PANEL);
                 break;
-            case FULL_API_REFERENCE:
-                setPanel(API_REFERENCE_PANEL);
+            case BASE_API:
+                setPanel(BASE_API_PANEL);
+                break;
+            case SOUND_API:
+                setPanel(SOUND_API_PANEL);
                 break;
             case START_TUTORIAL:
                 setUiState(SHOWING_TUTORIAL);
@@ -83,25 +88,28 @@ const App = () => {
     // than relying on them happening to line up.
     const selectedMenuChoice = () => {
         switch(panel) {
-            case API_REFERENCE_PANEL: return FULL_API_REFERENCE;
-            case ABSTRACT_DATA_TYPES_PANEL:       return ABSTRACT_DATA_TYPES;
-            case BASIC_USAGE_PANEL:   return QUICK_REFERENCE;
-            case WELCOME_PANEL:
-            default:                  return WELCOME;
+            case BASE_API_PANEL:            return BASE_API;
+            case SOUND_API_PANEL:           return SOUND_API;
+            case ABSTRACT_DATA_TYPES_PANEL: return ABSTRACT_DATA_TYPES;
+            case WELCOME_PANEL:             return WELCOME;
+            case BASIC_USAGE_PANEL:
+            default:                        return QUICK_REFERENCE;
         }
     }
 
     const displayPanel = () => {
         switch(panel) {
-            case API_REFERENCE_PANEL:
+            case BASE_API_PANEL:
                 return <ApiReferencePanel/>;
+            case SOUND_API_PANEL:
+                return <ApiReferencePanel sound={true}/>;
             case ABSTRACT_DATA_TYPES_PANEL:
                 return <AbstractDataTypesPanel/>;
-            case BASIC_USAGE_PANEL:
-                return <BasicUsagePanel/>;
             case WELCOME_PANEL:
-            default:
                 return <WelcomePanel/>;
+            case BASIC_USAGE_PANEL:
+            default:
+                return <BasicUsagePanel/>;
         }
     }
 

--- a/server/src/components/menu_constants.js
+++ b/server/src/components/menu_constants.js
@@ -1,9 +1,12 @@
 // These represent menu buttons.
 
-export const WELCOME = 0;
 export const QUICK_REFERENCE = 1;
-export const FULL_API_REFERENCE = 2;
+export const BASE_API = 2;
+export const SOUND_API = 6;
 export const ABSTRACT_DATA_TYPES = 5;
 export const START_TUTORIAL = 3;
 export const CLOSE_HELP = 4;
 
+// No longer a tab. The panel is still there and still the thing new users see
+// first if it is ever put back.
+export const WELCOME = 0;

--- a/server/src/components/topmenu.jsx
+++ b/server/src/components/topmenu.jsx
@@ -1,31 +1,31 @@
 import MenuButton from './menubutton.jsx'
-import { WELCOME, QUICK_REFERENCE, ABSTRACT_DATA_TYPES, FULL_API_REFERENCE, START_TUTORIAL, CLOSE_HELP } from './menu_constants.js';
+import { QUICK_REFERENCE, BASE_API, SOUND_API, ABSTRACT_DATA_TYPES, START_TUTORIAL, CLOSE_HELP } from './menu_constants.js';
 
-// Only the first three are tabs -- the last two are actions, so they never
+// Only the first four are tabs -- the last two are actions, so they never
 // show as selected.
 const TopMenu = ({ selectedMenuChoice, onMenuChange }) => {
     return (
         <div className="helpmenupanel">
-            <MenuButton
-                key="WELCOME"
-                text="Welcome"
-                selected={selectedMenuChoice == WELCOME}
-                onMenuButtonClick={() => onMenuChange(WELCOME)} />
             <MenuButton
                 key="QUICK_REFERENCE"
                 text="Quick Reference"
                 selected={selectedMenuChoice == QUICK_REFERENCE}
                 onMenuButtonClick={() => onMenuChange(QUICK_REFERENCE)} />
             <MenuButton
+                key="BASE_API"
+                text="Base API"
+                selected={selectedMenuChoice == BASE_API}
+                onMenuButtonClick={() => onMenuChange(BASE_API)} />
+            <MenuButton
+                key="SOUND_API"
+                text="Sound API"
+                selected={selectedMenuChoice == SOUND_API}
+                onMenuButtonClick={() => onMenuChange(SOUND_API)} />
+            <MenuButton
                 key="ABSTRACT_DATA_TYPES"
                 text="Abstract Data Types"
                 selected={selectedMenuChoice == ABSTRACT_DATA_TYPES}
                 onMenuButtonClick={() => onMenuChange(ABSTRACT_DATA_TYPES)} />
-            <MenuButton
-                key="FULL_API_REFERENCE"
-                text="Full API Reference"
-                selected={selectedMenuChoice == FULL_API_REFERENCE}
-                onMenuButtonClick={() => onMenuChange(FULL_API_REFERENCE)} />
             <MenuButton
                 key="START_TUTORIAL"
                 text="Start Tutorial"


### PR DESCRIPTION
Stacked on #362. Side quest.

Making sound and writing code are different jobs, and there are enough builtins for each that one list means scrolling past all of one to reach the other.

**Sound API**: Wavetable, Wave Math, Midi.
**Base API**: everything else.

Tabs are now Quick Reference, Base API, Sound API, Abstract Data Types, then Start Tutorial and Close Help as actions.

**Welcome is no longer a tab**, per your list, so help opens on the Quick Reference instead. The welcome panel, its constant and its case are all still there and still wired up, so putting the tab back is one `MenuButton`. Nothing else reaches it at the moment though — tell me if you would rather it were deleted outright or restored.

The filter tests which side a category falls on rather than listing what is left behind, so a category added later shows up in the Base API rather than in neither. Both tabs are the same component with a flag, so the section nav, back-to-top links and DOM-safe ids keep working in each.