### PR TITLE
[23/23] Add envelope-of

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -1303,6 +1303,55 @@ function createWavetableBuiltins() {
   measureBuiltin("peak-of", false,
       "The loudest sample in wt| within |window, as a wave. Leave |window out to get one number for the whole wave, which is what amplitude has always done. Use volume instead if you want what you hear rather than what the meter hits. Timebase tag (nn, secs, hz, b, samps) is on |window.");
 
+  Builtin.createBuiltin(
+    "envelope-of",
+    ["wt_", "attack#%?", "release#%?"],
+    function $envelopeOf(env, executionEnvironment) {
+      let wt = env.lb("wt");
+      let attack = env.lb("attack");
+      let release = env.lb("release");
+
+      let attackSamples = attack == UNBOUND
+          ? Math.round(0.005 * getSampleRate())
+          : convertTimeToSamples(attack);
+      let releaseSamples = release == UNBOUND
+          ? Math.round(0.05 * getSampleRate())
+          : convertTimeToSamples(release);
+      if (attackSamples < 0 || releaseSamples < 0) {
+        return constructFatalError("envelope-of: attack and release cannot be negative. Sorry!");
+      }
+
+      /*
+      Unlike volume and peak-of, this one runs forwards only and never looks
+      ahead. That is not an oversight: the whole point of an envelope follower
+      is that it rises and falls at different rates, and quick-to-rise
+      slow-to-fall only means anything if it is moving through the sound in
+      order.
+
+      The coefficient is how much of the old value survives one sample. Over
+      the given number of samples that leaves 1/e of the distance still to
+      travel, which is what makes attack and release read as times rather than
+      as arbitrary numbers.
+      */
+      let attackKeep = attackSamples < 1 ? 0 : Math.exp(-1 / attackSamples);
+      let releaseKeep = releaseSamples < 1 ? 0 : Math.exp(-1 / releaseSamples);
+
+      let dur = wt.getDuration();
+      let r = constructWavetable(dur);
+      let data = r.getData();
+      let level = 0;
+      for (let i = 0; i < dur; i++) {
+        let v = Math.abs(wt.valueAtSample(i));
+        let keep = v > level ? attackKeep : releaseKeep;
+        level = keep * level + (1 - keep) * v;
+        data[i] = level;
+      }
+      r.init();
+      return r;
+    },
+    "Follows how loud wt| is as it goes, rising over |attack and falling over |release, and returns that as a wave. This is the shape of the sound rather than the sound: multiply another wave by it and that wave takes on this one's dynamics. Rising fast and falling slow is what makes it read as an envelope rather than as a rectified copy -- the defaults are 5 milliseconds and 50. Timebase tag (nn, secs, hz, b, samps) is on |attack and |release."
+  );
+
   Builtin.aliasBuiltin("rms", "volume");
   // what this was called when it could only measure the whole wave
   Builtin.aliasBuiltin("amplitude", "peak-of");


### PR DESCRIPTION
Stacked on #364.

Follows how loud a wave is as it goes, rising over `attack` and falling over `release`, returned as a wave. Multiply another wave by it and that wave takes on this one's dynamics. Defaults are 5ms and 50ms; both take a timebase tag.

**It runs forwards only and never looks ahead**, unlike `volume` and `peak-of` in #364 which centre their window. That is the point rather than an oversight: rising fast and falling slow only means anything moving through the sound in order, so a follower has to be causal in a way a measurement does not.

**Verified the times are real times.** One attack into a burst the level reads 0.634 where 1−1/e is 0.632; one release after the burst ends it reads 0.368 where 1/e is 0.368. So `attack` and `release` are the time to cover 1−1/e of the distance, which is what those words mean everywhere else. A steady sine comes back nearly flat (ripple 0.035), which is the difference between an envelope and a rectified copy.

This is the builtin I split out of `amplitude` rather than adding attack and release to it — see the note at the end of #364. If you would rather have them collapsed, this is the one to fold in.

**It also completes `compress-shape` from #362.** That gave you a compressor's curve with no timing; `envelope-of` is the timing. `w* @sound ~(_waveshape ~(_envelope-of @sound_) ~(_compress-shape_)_)` is a real compressor, attack and release included.