### PR TITLE
[24/24] Add find-nearest-zero-crossing

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -1620,6 +1620,61 @@ function createWavetableBuiltins() {
   );
 
   Builtin.createBuiltin(
+    "find-nearest-zero-crossing",
+    ["wt_", "at#%"],
+    function $findNearestZeroCrossing(env, executionEnvironment, commandTags) {
+      let wt = env.lb("wt");
+      let total = wt.getDuration();
+      if (total < 2) {
+        return constructFatalError(
+            "find-nearest-zero-crossing: this wave is too short to have one. Sorry!");
+      }
+      let from = slicePointToSamples(env.lb("at"), null, total);
+      if (from < 0) from = 0;
+      if (from > total - 1) from = total - 1;
+
+      /*
+      A crossing is reported at the first sample of the new polarity, which is
+      the sample you want to cut on: a copy starting there starts from roughly
+      nothing. A run of zeros is not a sign change by itself, so silence in the
+      middle of a wave gives one crossing rather than two.
+      */
+      let best = -1;
+      let bestDist = 0;
+      let lastSign = 0;
+      for (let i = 0; i < total; i++) {
+        let v = wt.valueAtSample(i);
+        let sign = v > 0 ? 1 : (v < 0 ? -1 : 0);
+        if (sign == 0) continue;
+        if (lastSign != 0 && sign != lastSign) {
+          let dist = Math.abs(i - from);
+          if (best == -1 || dist < bestDist) {
+            best = i;
+            bestDist = dist;
+          }
+          // everything after this one is farther away than this one
+          if (i >= from) break;
+        }
+        lastSign = sign;
+      }
+      if (best == -1) {
+        return constructFatalError(
+            "find-nearest-zero-crossing: this wave never crosses zero. Sorry!");
+      }
+
+      if (hasCommandTag(commandTags, "of-total")) {
+        return constructFloat(best / total);
+      }
+      let timebase = timebaseFromTags(commandTags);
+      if (!timebase || timebase == "SAMPLES") {
+        return constructInteger(best);
+      }
+      return constructFloat(convertSamplesToTimebase(timebase, best));
+    },
+    "The point in wt| nearest to |at where the wave changes sign. Cutting or looping there instead of at |at is what keeps a splice from clicking. |at is a length, so it can be tagged with a timebase (nn, secs, hz, b, samps) or with of-total to read it as a fraction of this wave. The answer comes back in samples unless you tag the command with a timebase or with of-total."
+  );
+
+  Builtin.createBuiltin(
     "get-bpm",
     [],
     function $getBpm(env, executionEnvironment) {


### PR DESCRIPTION
Stacked on #365.

`find-nearest-zero-crossing` takes a wave and a position, and gives back the
nearest point where the wave changes sign — the point you actually want to cut
on, since a splice that starts from roughly nothing does not click.

```
~(_set-split-points @drums ~(_find-nearest-zero-crossing @drums %0.5 of-total_)_)
```

Position semantics match `set-split-points`: `|at` is a length, so it takes a
timebase tag (`nn`, `secs`, `hz`, `b`, `samps`) or `of-total` to read it as a
fraction of the wave. The answer comes back in samples unless the command is
tagged, same as `split-points-of`.

A run of zeros is not a sign change on its own, so silence in the middle of a
wave gives one crossing rather than two, and a wave that touches zero without
changing sign gives none there. A wave that never crosses zero at all is an
error rather than a silent zero.

Verified the search against a brute-force implementation at all 5300 positions
across eight waves — sine, DC, silence, a single step, a zero run, a zero touch,
noise, and a decaying tone — identical everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT