### PR TITLE
[28/28] Bring the midi builtins in line with the audio ones

### DIFF
--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -16,7 +16,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 import { Builtin } from '../nex/builtin.js'; 
-import { getMidiPorts, openMidiPort, isPortOpen, addMidiSequence, replaceMidiSequence, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+import { getMidiPorts, openMidiPort, isPortOpen, addMidiSequence, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
 		 sendMidiNoteWithDuration } from '../midifunctions.js'
 import { convertTimeToSamples, nexToTimebase, getSampleRate } from '../wavetablefunctions.js'
 import { constructClip } from '../nex/clip.js'
@@ -124,39 +124,39 @@ function createMidiBuiltins() {
 
 
 	/*
-	Reads one note out of a loop-midi list. Same shape send-midi-note takes,
+	Reads one note out of a play-midi list. Same shape send-midi-note takes,
 	plus a float tagged `time` saying where in the sequence it goes.
 	*/
 	function readSequenceNote(n) {
 		let kind = null;
 		let notenum = null;
 		for (let k of ['note', 'note-on', 'note-off']) {
-			let v = taggedInt(n, k, 'loop-midi');
+			let v = taggedInt(n, k, 'play-midi');
 			if (v !== null) { kind = k; notenum = v; break; }
 		}
 		if (kind == null) {
-			return { error: 'loop-midi: needs an int tagged note, note-on or note-off. Sorry!' };
+			return { error: 'play-midi: needs an int tagged note, note-on or note-off. Sorry!' };
 		}
 		if (kind != 'note') {
-			return { error: 'loop-midi: every note needs a duration, so tag it note. Sorry!' };
+			return { error: 'play-midi: every note needs a duration, so tag it note. Sorry!' };
 		}
 		if (notenum < 0 || notenum > 127) {
-			return { error: `loop-midi: ${notenum} is not a note (0-127). Sorry!` };
+			return { error: `play-midi: ${notenum} is not a note (0-127). Sorry!` };
 		}
-		let timenex = n.getChildTagged(newTagOrThrowOOM('time', 'loop midi, time'));
+		let timenex = n.getChildTagged(newTagOrThrowOOM('time', 'play midi, time'));
 		if (!timenex) {
-			return { error: 'loop-midi: every note needs a float tagged time. Sorry!' };
+			return { error: 'play-midi: every note needs a float tagged time. Sorry!' };
 		}
-		let durnex = n.getChildTagged(newTagOrThrowOOM('duration', 'loop midi, duration'));
+		let durnex = n.getChildTagged(newTagOrThrowOOM('duration', 'play midi, duration'));
 		if (!durnex) {
-			return { error: 'loop-midi: every note needs a duration. Sorry!' };
+			return { error: 'play-midi: every note needs a duration. Sorry!' };
 		}
-		let velocity = taggedInt(n, 'velocity', 'loop-midi');
+		let velocity = taggedInt(n, 'velocity', 'play-midi');
 		if (velocity == null) velocity = 127;
-		let channel = taggedInt(n, 'channel', 'loop-midi');
+		let channel = taggedInt(n, 'channel', 'play-midi');
 		if (channel == null) channel = 1;
 		if (channel < 1 || channel > 16) {
-			return { error: `loop-midi: no channel ${channel} (1-16). Sorry!` };
+			return { error: `play-midi: no channel ${channel} (1-16). Sorry!` };
 		}
 		let durTimebase = nexToTimebase(durnex);
 		return {
@@ -171,11 +171,11 @@ function createMidiBuiltins() {
 	}
 
 	Builtin.createBuiltin(
-		'loop-midi on',
+		'play-midi on',
 		[ 'seq()', 'port()', 'clip?' ],
-		function $loopMidi(env, executionEnvironment) {
+		function $playMidi(env, executionEnvironment) {
 			let list = env.lb('seq');
-			let port = portIdOrError(env.lb('port'), 'loop-midi');
+			let port = portIdOrError(env.lb('port'), 'play-midi');
 			if (port.error) return port.error;
 
 			let events = [];
@@ -193,7 +193,7 @@ function createMidiBuiltins() {
 				events.push(e);
 			}
 			if (events.length == 0) {
-				return constructFatalError('loop-midi: nothing to play. Sorry!');
+				return constructFatalError('play-midi: nothing to play. Sorry!');
 			}
 
 			// The sequence is as long as its last note nominally ends, plus the
@@ -206,32 +206,39 @@ function createMidiBuiltins() {
 			}
 			let lengthSeconds = nominalEnd + spacerSeconds;
 
-			let what = 'midi loop, ' + events.length + ' note' + (events.length == 1 ? '' : 's');
+			// the clip already says it is midi, so this says what is in it
+			let what = events.length + ' note' + (events.length == 1 ? '' : 's');
 
 			// Handed a clip, replace what it names rather than starting a
 			// second loop alongside it.
-			let clip = env.lb('clip');
-			if (clip != UNBOUND) {
-				if (!Utils.isClip(clip) || clip.getKind() != 'midi loop') {
-					return constructFatalError('loop-midi: that is not a midi clip. Sorry!');
+			let arg = env.lb('clip');
+			let clip = null;
+			if (arg != UNBOUND) {
+				if (!Utils.isClip(arg) || arg.getKind() != 'midi loop') {
+					return constructFatalError('play-midi: that is not a midi clip. Sorry!');
 				}
-				let ids = clip.getIds();
-				if (ids.length != 1
-						|| !replaceMidiSequence(ids[0], port.id, events, lengthSeconds)) {
-					return constructFatalError('loop-midi: that loop already ended. Sorry!');
-				}
-				clip.setIds(ids, what);
-				clipStartedPlaying(clip, ids);
-				return clip;
+				clip = arg;
+				// Out at the boundary and back in at the same one, the way an
+				// audio loop is replaced. Stopping the old sequence now instead
+				// would send its note offs early and cut a note that is sounding.
+				endLoops(clip.getIds(), true /* at the cycle end */);
 			}
 
 			let id = addMidiSequence(port.id, events, lengthSeconds);
-			let newclip = constructClip('midi loop', what, [ id ], endLoops);
-			clipStartedPlaying(newclip, [ id ]);
-			return newclip;
+			if (clip) {
+				clip.setIds([ id ], what);
+			} else {
+				clip = constructClip('midi loop', what, [ id ], endLoops);
+			}
+			// the midi system owns it while it plays, and how long that lasts is
+			// decided by whether anything else owns it too
+			clipStartedPlaying(clip, [ id ]);
+			return clip;
 		},
-		'Plays a list of midi notes in a loop on |port, joining the global cycle at its next boundary. Each note is what send-midi-note takes, with a float tagged time saying where in the sequence it falls. A bare number at the end of the list is the gap before the sequence repeats. Returns a clip, which ends the loop when it is deleted, or at the next boundary if passed to end-seq. Passing that clip back in |clip replaces what it is playing rather than starting a second loop.'
+		'Plays a list of midi notes in a loop on |port, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, with a float tagged time saying where in the sequence it falls. A bare number at the end of the list is the gap before the sequence repeats. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. Passing that clip back in |clip replaces what it is playing at the next boundary rather than starting a second loop, and you get the same clip back.'
 	);
+
+	Builtin.aliasBuiltin('loop-midi on', 'play-midi on');
 
 	Builtin.createBuiltin(
 		'send-midi-data on',

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -143,7 +143,7 @@ function createWavetableBuiltins() {
 
       if (arg != UNBOUND && Utils.isClip(arg)) {
         if (arg.getKind() != "audio loop") {
-          return constructFatalError("loop-play: that is not an audio clip. Sorry!");
+          return constructFatalError("play: that is not an audio clip. Sorry!");
         }
         clip = arg;
         channelnumbers = clip.getChannels();
@@ -174,7 +174,7 @@ function createWavetableBuiltins() {
       clipStartedPlaying(clip, ids);
       return clip;
     },
-    "Starts playing wt| at the next measure start, and returns a clip naming it. It plays for as long as something holds that clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |channelsorclip is either the channels to play on, or a clip returned by an earlier loop-play -- given a clip, the loop it names is replaced at the next measure start, staying on the channels it is already on, and you get the same clip back. If it is not provided, the sound is played on the first 2 channels. If it and/or |wt are lists, Vodka will do its best to match up sounds with channels."
+    "Starts playing wt| at the next measure start, and returns a clip naming it. It plays for as long as something holds that clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |channelsorclip is either the channels to play on, or a clip returned by an earlier play -- given a clip, the loop it names is replaced at the next measure start, staying on the channels it is already on, and you get the same clip back. If it is not provided, the sound is played on the first 2 channels. If it and/or |wt are lists, Vodka will do its best to match up sounds with channels."
   );
 
   // what it was called before it could do both

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -18,7 +18,7 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 import { Tag } from './tag.js'
 import { constructOrg, convertJSMapToOrg } from './nex/org.js'
 import { constructFatalError } from './nex/eerror.js'
-import { addCycleMember, replaceCycleMember, contextTimeToPerformanceTime } from './webaudio.js'
+import { addCycleMember, contextTimeToPerformanceTime } from './webaudio.js'
 
 
 var midi = null;
@@ -219,15 +219,31 @@ Every message is handed to the browser with a timestamp, so the timing does not
 depend on when any of this javascript runs. The cycle boundary is in audio time
 and midi wants wall time, which is what contextTimeToPerformanceTime is for.
 */
+// kept so a clip can ask what its sequence last played
+let midiMembers = {};
+
 function addMidiSequence(portId, events, lengthSeconds) {
 	let member = makeMidiCycleMember(portId, events, lengthSeconds);
-	return addCycleMember(member);
+	let id = addCycleMember(member);
+	member.id = id;
+	midiMembers[id] = member;
+	return id;
 }
 
-// Swaps what a running midi loop plays. The notes for the next cycle are read
-// at the boundary, so replacing them here is enough.
-function replaceMidiSequence(id, portId, events, lengthSeconds) {
-	return replaceCycleMember(id, makeMidiCycleMember(portId, events, lengthSeconds));
+/*
+What a midi clip shows instead of a position in samples: the note whose start
+has most recently gone past. Everything is scheduled ahead with a timestamp, so
+this is a question about the clock rather than about anything that has happened.
+*/
+function getMidiLastNote(id) {
+	let member = midiMembers[id];
+	if (!member) return -1;
+	let now = performance.now();
+	let list = member.scheduled;
+	for (let i = list.length - 1; i >= 0; i--) {
+		if (list[i].at <= now) return list[i].note;
+	}
+	return -1;
 }
 
 function makeMidiCycleMember(portId, events, lengthSeconds) {
@@ -235,7 +251,14 @@ function makeMidiCycleMember(portId, events, lengthSeconds) {
 	let member = {
 		lengthSeconds: lengthSeconds,
 		scheduled: [],
+		thisCycle: [],
 		start: function(startTime, cycleLen) {
+			// A cycle is scheduled a little before it starts, so notes from the
+			// cycle before this one can still be sounding. Two cycles' worth is
+			// therefore everything that might need a note off, and keeping only
+			// that stops the list growing for as long as the loop runs.
+			let previous = member.thisCycle;
+			member.thisCycle = [];
 			// the sequence repeats within the cycle if the cycle is longer
 			for (let base = 0; base < cycleLen; base += lengthSeconds) {
 				for (let i = 0; i < events.length; i++) {
@@ -251,9 +274,13 @@ function makeMidiCycleMember(portId, events, lengthSeconds) {
 					if (dur < 0.001) dur = 0.001;
 					let offAt = contextTimeToPerformanceTime(startTime + at + dur);
 					out.send([statusByte(0x80, e.channel), e.note, 0], offAt);
-					member.scheduled.push({ channel: e.channel, note: e.note });
+					member.thisCycle.push({ channel: e.channel, note: e.note, at: onAt });
 				}
 			}
+			member.scheduled = previous.concat(member.thisCycle);
+		},
+		retired: function() {
+			delete midiMembers[member.id];
 		},
 		stop: function() {
 			// messages already handed over cannot be recalled, so silence
@@ -267,6 +294,7 @@ function makeMidiCycleMember(portId, events, lengthSeconds) {
 				out.send([statusByte(0x80, n.channel), n.note, 0]);
 			}
 			member.scheduled = [];
+			member.thisCycle = [];
 		}
 	};
 	return member;
@@ -337,5 +365,5 @@ function getMidiPorts(incb) {
 }
 
 
-export { getMidiPorts, openMidiPort, isPortOpen, addMidiListener, addMidiSequence, replaceMidiSequence, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
+export { getMidiPorts, openMidiPort, isPortOpen, addMidiListener, addMidiSequence, getMidiLastNote, sendMidiData, sendMidiNoteOn, sendMidiNoteOff,
 		 sendMidiNoteWithDuration, anyMidiNotesSounding, midiPanic }

--- a/server/src/nex/clip.js
+++ b/server/src/nex/clip.js
@@ -17,7 +17,8 @@ along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
 
 import { Nex } from './nex.js'
 import { heap } from '../heap.js'
-import { getLoopPositionSamples } from '../webaudio.js'
+import { getLoopPositionSamples, loopExists } from '../webaudio.js'
+import { getMidiLastNote } from '../midifunctions.js'
 
 /*
 A clip is a running loop -- audio or midi -- as something you can hold. Made by
@@ -27,7 +28,7 @@ than like a value.
 It holds ids rather than the sound itself, plus whatever else describes the
 loop: which channels it is on, how to end it. Deleting a clip stops it.
 
-Passing a clip back to loop-play replaces what it names rather than starting
+Passing a clip back to play replaces what it names rather than starting
 something alongside it, which is what lets an expression be re-evaluated in
 place. A clip is not a generic handle: it names a loop and nothing else.
 */
@@ -171,10 +172,18 @@ class Clip extends Nex {
 		this.startPositionCounter();
 	}
 
+	isMidi() {
+		return this.kind == 'midi loop';
+	}
+
 	/*
 	The counter writes one string into its own span, so it never asks the
 	document to render -- watching a clip count samples must not cost anything
 	that editing would notice.
+
+	An audio clip counts samples, because that is what it is playing. A midi
+	clip has no position of its own -- it sends messages and the sound is made
+	somewhere else -- so it shows the last note it played instead.
 	*/
 	startPositionCounter() {
 		if (this.posFrame) return;
@@ -185,15 +194,23 @@ class Clip extends Nex {
 				this.showPosition(-1);
 				return;
 			}
-			let pos = this.ids.length ? getLoopPositionSamples(this.ids[0]) : -1;
+			let alive = this.ids.length && loopExists(this.ids[0]);
+			let pos = -1;
+			if (alive) {
+				pos = this.isMidi()
+						? getMidiLastNote(this.ids[0])
+						: getLoopPositionSamples(this.ids[0]);
+			}
 			this.showPosition(pos);
 			// stopped from somewhere else, like the stop button -- give up
-			// rather than spin for the rest of the session
-			if (pos < 0 && ++quiet > 60) {
+			// rather than spin for the rest of the session. Having no position
+			// is not that: a loop waiting for the boundary is still ours, and a
+			// midi loop has no note to show until its first one goes past.
+			if (!alive && ++quiet > 60) {
 				this.posFrame = null;
 				return;
 			}
-			if (pos >= 0) quiet = 0;
+			if (alive) quiet = 0;
 			this.posFrame = window.requestAnimationFrame(step);
 		};
 		this.posFrame = window.requestAnimationFrame(step);
@@ -201,7 +218,11 @@ class Clip extends Nex {
 
 	showPosition(pos) {
 		if (!this.posSpan) return;
-		this.posSpan.textContent = pos < 0 ? '--' : (pos + ' samps');
+		if (pos < 0) {
+			this.posSpan.textContent = '--';
+			return;
+		}
+		this.posSpan.textContent = this.isMidi() ? ('note ' + pos) : (pos + ' samps');
 	}
 
 	getDefaultHandler() {

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -442,6 +442,7 @@ function startCycleAt(startTime) {
 	}
 	for (let id in cycleLoops) {
 		if (cycleLoops[id].endAfterCycle) {
+			retireMember(cycleLoops[id]);
 			delete cycleLoops[id];
 		}
 	}
@@ -508,7 +509,7 @@ function addCycleMember(loop) {
 	Starting is deferred by a microtask so that everything added in one go
 	starts together.
 
-	loop-play adds one loop per channel, one at a time. Starting the cycle as
+	play adds one loop per channel, one at a time. Starting the cycle as
 	soon as the first arrived meant the second was already too late for it and
 	waited for the next boundary -- so a stereo pair played left only for its
 	first time round, then both from then on.
@@ -527,6 +528,16 @@ Where a running loop is, for the counter on a clip. Reckoned the same way the
 audition player does it, and like that one it is a readout rather than anything
 to synchronise against. -1 when the loop is not running.
 */
+/*
+Whether a loop is still one of ours, which is not the same question as where it
+is. A loop waiting for the next boundary has no position yet but has not gone
+anywhere, and a clip that could not tell those apart would give up watching a
+loop that has not started.
+*/
+function loopExists(id) {
+	return !!(cycleLoops[id] || cyclePending[id]);
+}
+
 function getLoopPositionSamples(id) {
 	if (!ctx) return -1;
 	let loop = cycleLoops[id];
@@ -534,17 +545,6 @@ function getLoopPositionSamples(id) {
 	let elapsed = ctx.currentTime - (cycleNextBoundaryTime - cycleLengthSeconds());
 	if (elapsed < 0) return -1;
 	return Math.floor((elapsed * SAMPLE_RATE) % (loop.lengthSeconds * SAMPLE_RATE));
-}
-
-// Same idea for a member that brings its own start and stop, like midi.
-function replaceCycleMember(id, member) {
-	let existing = cycleLoops[id] || cyclePending[id];
-	if (!existing) return false;
-	if (existing.stop) existing.stop();
-	member.endAfterCycle = false;
-	if (cycleLoops[id]) cycleLoops[id] = member;
-	if (cyclePending[id]) cyclePending[id] = member;
-	return true;
 }
 
 /*
@@ -585,6 +585,12 @@ function togglePauseLoops(ids) {
 	return pauseLoops(ids, loopsArePlaying(ids));
 }
 
+// A member that keeps its own records -- midi does -- gets told when it leaves
+// the cycle, so nothing has to hold on to it after that.
+function retireMember(loop) {
+	if (loop && loop.retired) loop.retired();
+}
+
 function endLoops(ids, atCycleEnd) {
 	for (let i = 0; i < ids.length; i++) {
 		let id = ids[i];
@@ -598,6 +604,7 @@ function endLoops(ids, atCycleEnd) {
 				try { loop.node.stop(); } catch (e) {}
 				loop.node.disconnect();
 			}
+			retireMember(loop);
 			delete cycleLoops[id];
 			delete cyclePending[id];
 		}
@@ -733,5 +740,5 @@ async function getFileAsBuffer(filepath) {
 }
 
 
-export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, clipStartedPlaying, pauseLoops, togglePauseLoops, loopsArePlaying, addCycleMember, replaceCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
+export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, loopExists, clipStartedPlaying, pauseLoops, togglePauseLoops, loopsArePlaying, addCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
 


### PR DESCRIPTION
Stacked on #369. The midi plumbing already rode the same cycle as audio; this is
the naming and the two places where it behaved differently.

**`loop-midi on` → `play-midi on`**, your parallel to `play`. `loop-midi on` is
kept as an alias, the same way `loop-play` is. All its error prefixes follow.

**Replacement swaps at the boundary now.** It was calling `replaceCycleMember`,
which stopped the old sequence immediately and fired its note-offs — so swapping
a midi loop could cut a note that was still sounding. It now does what audio
does: `endLoops(ids, atCycleEnd)` and a fresh sequence, so the old one plays out
its pass. `replaceCycleMember` and `replaceMidiSequence` are gone, the way
`replaceLoop` went.

**A midi clip shows the last note it played.** An audio clip counts samples
because that is what it is playing; a midi clip sends messages and the sound is
made somewhere else, so it has no position of its own. It reads `note 64`
instead of `12345 samps`. Its second line drops the redundant "midi loop, " and
just says `3 notes`, since the line above already says MIDI LOOP.

**Stale docs fixed.** `loop-midi`'s doc still promised `end-seq`, which is
deleted, and the old delete-stops-it-instantly rule, which is inverted. It now
says what `play` says. `play` itself still said "loop-play" in one error and in
its doc.

Two bugs turned up on the way:

- The clip counter could not tell "this loop is gone" from "this loop has no
  position yet", so it gave up after ~1 second of no position. A loop added
  mid-cycle sits in `cyclePending` until the boundary, so with a cycle longer
  than a second **any clip you started would show `--` forever**. Liveness now
  comes from `loopExists`, which counts pending loops. This one was hitting
  audio too.
- A midi sequence's `scheduled` list grew by a full sequence every cycle for as
  long as the loop ran, and was only ever cleared by `stop`. It now keeps this
  cycle and the previous one, which is everything that could still need a note
  off.

Verified the note bookkeeping against a simulation: the right note at ten points
across a sequence that repeats twice inside a cycle, the right note across a
boundary, correct handling of a sequence longer than the cycle, and the list
holding at 12 entries after 40 cycles instead of growing.

I have not heard this — no midi hardware here. Worth a listen before it merges,
particularly the swap-at-boundary behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT