### PR TITLE
[35/35] Answer everything waiting on midi access, including on failure

### DIFF
--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -44,7 +44,14 @@ function createMidiBuiltins() {
 			dv.set(new GenericActivationFunctionGenerator(
 				'list-midi-ports', 
 				function(callback, exp) {
-					getMidiPorts(function(devs) {
+					getMidiPorts(function(devs, err) {
+						// an error rather than nothing, so anything waiting on
+						// this gets to carry on rather than waiting forever
+						if (err) {
+							callback(constructFatalError(
+									'list-midi-ports: no midi access in this browser. Sorry!'));
+							return;
+						}
 						// devices will just be a string
 						// convert to nice estrings
 						let r = constructOrg();
@@ -115,7 +122,12 @@ function createMidiBuiltins() {
 			dv.set(new GenericActivationFunctionGenerator(
 				'open-midi-port',
 				function(callback, exp) {
-					openMidiPort(idstr, function(desc) {
+					openMidiPort(idstr, function(desc, err) {
+						if (err) {
+							callback(constructFatalError(
+									'open-midi-port: no midi access in this browser. Sorry!'));
+							return;
+						}
 						if (!desc) {
 							callback(constructFatalError(
 									`open-midi-port: no port with id ${idstr}. Sorry!`));

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -22,7 +22,13 @@ import { addCycleMember, contextTimeToPerformanceTime } from './webaudio.js'
 
 
 var midi = null;
-var setupcb = null;
+/*
+Everything waiting on midi access, not just the last thing that asked. There is
+one request however many things are waiting on it, and every one of them gets an
+answer -- an error if it failed, so that a deferred value waiting on midi
+finishes rather than sitting there forever.
+*/
+var setupcbs = [];
 
 const inputListeners = {};
 const inputsBeingListenedTo = {};
@@ -34,26 +40,40 @@ function playWavetableOnMidiInput(wt, midiInput) {
 	
 }
 
+function notifyMidiSetup(err) {
+	let waiting = setupcbs;
+	setupcbs = [];
+	for (let i = 0; i < waiting.length; i++) {
+		waiting[i](err);
+	}
+}
+
 function onMIDISuccess(midiAccess) {
 	console.log('MIDI ready');
 	console.log(midiAccess);
 	midi = midiAccess;
-	if (setupcb) {
-		setupcb();
-	}
+	notifyMidiSetup(null);
 }
 
 function onMIDIFailure(msg) {
 	console.log("failed to do midi " + msg);
-	midi = "i failed";
+	/*
+	A failure is not remembered. Asking again is how you recover after granting
+	permission, and a browser that has already refused answers the second
+	request without putting anything in front of the user, so this cannot turn
+	into a run of prompts.
+	*/
+	notifyMidiSetup('' + msg);
 }
 
 function maybeSetupMidi(cb) {
-	if (!midi) {
-		setupcb = cb;
+	if (midi) {
+		cb(null);
+		return;
+	}
+	setupcbs.push(cb);
+	if (setupcbs.length == 1) {
 		navigator.requestMIDIAccess().then( onMIDISuccess, onMIDIFailure );
-	} else {
-		cb();
 	}
 }
 
@@ -381,7 +401,11 @@ function midiPanic() {
 // A port org is saved with the document, so after a refresh it comes back as
 // just a name and an id. This asks for access again and opens that one port.
 function openMidiPort(portId, incb) {
-	let cb = function() {
+	maybeSetupMidi(function(err) {
+		if (err) {
+			incb(null, err);
+			return;
+		}
 		let port = midi.outputs.get(portId);
 		if (!port) {
 			port = midi.inputs.get(portId);
@@ -393,12 +417,15 @@ function openMidiPort(portId, incb) {
 		port.open();
 		openedPorts[portId] = true;
 		incb(describePort(port));
-	}
-	maybeSetupMidi(cb);
+	});
 }
 
 function getMidiPorts(incb) {
-	let cb = function() {
+	maybeSetupMidi(function(err) {
+		if (err) {
+			incb(null, err);
+			return;
+		}
 		let r = [];
 		for (let entry of midi.inputs) {
 			r.push(describePort(entry[1]));
@@ -407,8 +434,7 @@ function getMidiPorts(incb) {
 			r.push(describePort(entry[1]));
 		}
 		incb(r);
-	}
-	maybeSetupMidi(cb);
+	});
 }
 
 


### PR DESCRIPTION
Stacked on #376. This is the bug behind "why doesn't this ever log hello".

`maybeSetupMidi` had two ways to lose a caller forever:

1. **`onMIDIFailure` never called the callback.** If midi access was refused, or
   the permission prompt was never answered, whatever asked for it just waited.
   It also set `midi = "i failed"` — a *truthy* string — so every later call took
   the "already set up" branch and walked straight into `midi.inputs` on a
   string.
2. **`setupcb` was a single slot.** Two things asking before midi was ready meant
   the second overwrote the first, and the first was never called.

Either one leaves `list-midi-ports` sitting on its "listing midi ports" message
permanently. And since argument evaluation stops at the first deferred value that
hasn't finished — which is deliberate, and what makes `begin` read in order —
nothing after it in a `begin` ever runs.

Now: waiting callers are a list, every one of them is answered, and a failure is
answered with an error so the deferred value finishes instead of hanging.
`list-midi-ports` and `open-midi-port` turn that into a normal vodka error, with
the raw browser message still going to the console.

A failure is deliberately not remembered. Asking again is how you recover after
granting permission, and a browser that has already refused answers the second
request without putting anything in front of the user, so retrying can't turn
into a run of prompts.

Not verified by ear — no midi hardware here. Refusing permission in the browser
should now give an error rather than a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT