### PR TITLE
[36] Notify a listener that arrives after the deferred already finished

### DIFF
--- a/server/src/nex/deferredvalue.js
+++ b/server/src/nex/deferredvalue.js
@@ -52,7 +52,18 @@ class DeferredValue extends NexContainer {
 			return;
 		}
 		this.listeners.push(obj);
-		if (this._finished) {
+		/*
+		A listener that arrives after the value has already finished still has
+		to be told, or it waits for a notification that has already been sent.
+		This is not a rare case: a deferred command whose body returns without
+		waiting finishes inside its own evaluate, so whatever is evaluating it
+		as an argument only gets to listen afterwards.
+
+		(This tested this._finished, which is a field on DeferredCommand and
+		not on this class, so it was always undefined and the renotify never
+		happened.)
+		*/
+		if (this.isFinished()) {
 			eventQueueDispatcher.enqueueRenotifyDeferredListeners(this);
 		}
 	}


### PR DESCRIPTION
You were right and I was wrong — this is your bug, and it has nothing to do with
midi.

`deferredvalue.js:55`:

```js
addListener(obj) {
    if (this.hasListener(obj)) return;
    this.listeners.push(obj);
    if (this._finished) {                                  // always undefined
        eventQueueDispatcher.enqueueRenotifyDeferredListeners(this);
    }
}
```

**`_finished` is never assigned in `DeferredValue`.** That class tracks its state
in `this.state` (`this.state = DVSTATE_FINISHED`, line 161). `_finished` is a
field on `DeferredCommand` (`deferredcommand.js:46`) — the name was copied from
the wrong class. So the guard is always false, the renotify never fires, and
**any listener registered on an already-finished deferred value is never told.**
It waits forever for a notification that was already sent.

The renotify machinery itself was fine (`eventqueue.js:219`). Only the guard was
wrong. One line.

**Why it only bit the doubled case**, which is exactly what you spotted:

- `~list-midi-ports` — the builtin hands back a deferred that is still waiting on
  the browser. The argument evaluator listens while it is pending, and
  `notifyAllListeners` reaches it when it finishes. Works.
- `*list-midi-ports` — `DeferredCommand.evaluate` activates immediately, the body
  has no arguments to wait for, so it runs and calls `this._returnedValue.finish()`
  **directly** (`deferredcommand.js:220`), not through the event queue. The outer
  deferred is therefore already finished by the time `evaluate` returns. The
  argument evaluator then listens to a finished value — and is never told. `begin`
  waits forever and `jslog` is never evaluated.

So your reasoning was right the whole way: a deferred of a deferred *should*
resolve. It resolves; nobody is told.

**This supersedes #377 as the explanation.** The `maybeSetupMidi` bugs there are
real — a refused midi permission does drop its callback, and `midi = "i failed"`
does poison every later call — but that is not what you hit, and I should not
have offered it as the fix while I still had an unproven assumption in the chain.
Merge or drop #377 on its own merits; it's based on #376 and this one is too, so
they're independent.

Worth a look after this lands: any deferred command that completes without
waiting finishes inside its own `evaluate`, so this fix is on the hot path for
every one of them, not just yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT