### PR TITLE
[37] play-midi sequences: implicit times, rests, and no trailing spacer

### DIFF
--- a/server/namedsessions/shellraiser/setup
+++ b/server/namedsessions/shellraiser/setup
@@ -1,0 +1,1 @@
+v2:@setup-midi

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -263,7 +263,6 @@ function createMidiBuiltins() {
 			}
 
 			let events = [];
-			let spacerSeconds = 0;
 			// where the next entry starts if it does not say, and how long the
 			// sequence has got to so far
 			let cursorSeconds = 0;
@@ -271,10 +270,9 @@ function createMidiBuiltins() {
 			let n = list.numChildren();
 			for (let i = 0; i < n; i++) {
 				let c = list.getChildAt(i);
-				// a bare number last is the gap before the sequence repeats
-				if (i == n - 1 && !c.isNexContainer()) {
-					spacerSeconds = convertTimeToSamples(c) / getSampleRate();
-					break;
+				if (!c.isNexContainer()) {
+					return constructFatalError(
+							'play-midi: every entry has to be an org. Sorry!');
 				}
 				let e = readSequenceEntry(c, cursorSeconds);
 				if (e.error) return constructFatalError(e.error);
@@ -287,11 +285,11 @@ function createMidiBuiltins() {
 				return constructFatalError('play-midi: nothing to play. Sorry!');
 			}
 
-			// The sequence is as long as its last entry nominally ends, plus the
-			// gap. Nominally: shortening a note to keep it clear of the next one
-			// gives the time back to the gap, so it never changes the length. A
-			// rest at the end counts, which is one way to put space there.
-			let lengthSeconds = nominalEnd + spacerSeconds;
+			// The sequence is as long as its last entry nominally ends. Nominally:
+			// shortening a note to keep it clear of the next one is a note off
+			// sent early, not a shorter sequence. A rest at the end counts, which
+			// is how you put space before the repeat.
+			let lengthSeconds = nominalEnd;
 
 			// the clip already says it is midi, so this says what is in it
 			let what = events.length + ' note' + (events.length == 1 ? '' : 's');
@@ -314,7 +312,7 @@ function createMidiBuiltins() {
 			clipStartedPlaying(clip, [ id ]);
 			return clip;
 		},
-		'Plays a list of midi notes in a loop, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, and may carry a float tagged time saying where in the sequence it falls. Without a time it starts where the entry before it ended, so a list of notes carrying nothing but durations plays one after another. An entry with a duration and no note number is a rest: it takes up its time and sounds nothing, and a rest at the end is one way to put space before the repeat. A bare number at the end of the list is another. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |portorclip is either the port to play on, or a clip from an earlier play-midi -- given a clip, what it is playing is replaced at the next boundary, staying on the port it is already on, and you get the same clip back. Given neither, it plays on the port set by set-default-port.'
+		'Plays a list of midi notes in a loop, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, and may carry a float tagged time saying where in the sequence it falls. Without a time it starts where the entry before it ended, so a list of notes carrying nothing but durations plays one after another. An entry with a duration and no note number is a rest: it takes up its time and sounds nothing, and a rest at the end is how you put space before the sequence repeats. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |portorclip is either the port to play on, or a clip from an earlier play-midi -- given a clip, what it is playing is replaced at the next boundary, staying on the port it is already on, and you get the same clip back. Given neither, it plays on the port set by set-default-port.'
 	);
 
 	Builtin.aliasBuiltin('loop-midi on', 'play-midi');

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -150,31 +150,56 @@ function createMidiBuiltins() {
 
 
 	/*
-	Reads one note out of a play-midi list. Same shape send-midi-note takes,
-	plus a float tagged `time` saying where in the sequence it goes.
+	Reads one entry out of a play-midi list. Same shape send-midi-note takes,
+	plus an optional float tagged `time` saying where in the sequence it goes.
+
+	Without a time it starts where the entry before it ended, so a list of notes
+	carrying nothing but durations plays one after another. Without a note number
+	it is a rest: it takes up its duration and sounds nothing.
 	*/
-	function readSequenceNote(n) {
+	function readSequenceEntry(n, atSeconds) {
 		let kind = null;
 		let notenum = null;
 		for (let k of ['note', 'note-on', 'note-off']) {
 			let v = taggedInt(n, k, 'play-midi');
 			if (v !== null) { kind = k; notenum = v; break; }
 		}
-		if (kind == null) {
-			return { error: 'play-midi: needs an int tagged note, note-on or note-off. Sorry!' };
+		let durnex = n.getChildTagged(newTagOrThrowOOM('duration', 'play midi, duration'));
+
+		/*
+		A rest is a duration with no note number. Something with neither is still an
+		error rather than a rest of the default length, so that a mistyped note tag
+		says so instead of quietly turning into silence.
+		*/
+		if (kind == null && !durnex) {
+			return { error: 'play-midi: an entry needs a note number or a duration. Sorry!' };
 		}
-		if (kind != 'note') {
+		if (kind != null && kind != 'note') {
 			return { error: 'play-midi: every note needs a duration, so tag it note. Sorry!' };
 		}
-		if (notenum < 0 || notenum > 127) {
+		if (kind != null && (notenum < 0 || notenum > 127)) {
 			return { error: `play-midi: ${notenum} is not a note (0-127). Sorry!` };
 		}
+
+		// a time of its own overrides where the entry before it left off, and the
+		// entries after it then follow from here
 		let timenex = n.getChildTagged(newTagOrThrowOOM('time', 'play midi, time'));
-		if (!timenex) {
-			return { error: 'play-midi: every note needs a float tagged time. Sorry!' };
+		if (timenex) {
+			atSeconds = convertTimeToSamples(timenex) / getSampleRate();
 		}
+
 		// velocity and channel already have defaults, so a duration has one too
-		let durnex = n.getChildTagged(newTagOrThrowOOM('duration', 'play midi, duration'));
+		let durTimebase = durnex ? nexToTimebase(durnex) : 'BEATS';
+		let durSamples = durnex
+				? convertTimeToSamples(durnex)
+				: convertTimeToSamples(1, 'BEATS');
+		let durationSeconds = durSamples / getSampleRate();
+		let endsAtSeconds = atSeconds + durationSeconds;
+
+		if (kind == null) {
+			return { event: null, endsAtSeconds: endsAtSeconds };
+		}
+
 		let velocity = taggedInt(n, 'velocity', 'play-midi');
 		if (velocity == null) velocity = 127;
 		let channel = taggedInt(n, 'channel', 'play-midi');
@@ -182,18 +207,17 @@ function createMidiBuiltins() {
 		if (channel < 1 || channel > 16) {
 			return { error: `play-midi: no channel ${channel} (1-16). Sorry!` };
 		}
-		let durTimebase = durnex ? nexToTimebase(durnex) : 'BEATS';
-		let durSamples = durnex
-				? convertTimeToSamples(durnex)
-				: convertTimeToSamples(1, 'BEATS');
 		return {
-			atSeconds: convertTimeToSamples(timenex) / getSampleRate(),
-			durationSeconds: durSamples / getSampleRate(),
-			// only beats are shortened; anything else asked for that length
-			shortenable: durTimebase == 'BEATS',
-			note: notenum,
-			velocity: velocity,
-			channel: channel
+			event: {
+				atSeconds: atSeconds,
+				durationSeconds: durationSeconds,
+				// only beats are shortened; anything else asked for that length
+				shortenable: durTimebase == 'BEATS',
+				note: notenum,
+				velocity: velocity,
+				channel: channel
+			},
+			endsAtSeconds: endsAtSeconds
 		};
 	}
 
@@ -240,6 +264,10 @@ function createMidiBuiltins() {
 
 			let events = [];
 			let spacerSeconds = 0;
+			// where the next entry starts if it does not say, and how long the
+			// sequence has got to so far
+			let cursorSeconds = 0;
+			let nominalEnd = 0;
 			let n = list.numChildren();
 			for (let i = 0; i < n; i++) {
 				let c = list.getChildAt(i);
@@ -248,22 +276,21 @@ function createMidiBuiltins() {
 					spacerSeconds = convertTimeToSamples(c) / getSampleRate();
 					break;
 				}
-				let e = readSequenceNote(c);
+				let e = readSequenceEntry(c, cursorSeconds);
 				if (e.error) return constructFatalError(e.error);
-				events.push(e);
+				// a rest has no event, but it still takes up its time
+				if (e.event) events.push(e.event);
+				cursorSeconds = e.endsAtSeconds;
+				if (e.endsAtSeconds > nominalEnd) nominalEnd = e.endsAtSeconds;
 			}
 			if (events.length == 0) {
 				return constructFatalError('play-midi: nothing to play. Sorry!');
 			}
 
-			// The sequence is as long as its last note nominally ends, plus the
+			// The sequence is as long as its last entry nominally ends, plus the
 			// gap. Nominally: shortening a note to keep it clear of the next one
-			// gives the time back to the gap, so it never changes the length.
-			let nominalEnd = 0;
-			for (let i = 0; i < events.length; i++) {
-				let end = events[i].atSeconds + events[i].durationSeconds;
-				if (end > nominalEnd) nominalEnd = end;
-			}
+			// gives the time back to the gap, so it never changes the length. A
+			// rest at the end counts, which is one way to put space there.
 			let lengthSeconds = nominalEnd + spacerSeconds;
 
 			// the clip already says it is midi, so this says what is in it
@@ -287,7 +314,7 @@ function createMidiBuiltins() {
 			clipStartedPlaying(clip, [ id ]);
 			return clip;
 		},
-		'Plays a list of midi notes in a loop, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, with a float tagged time saying where in the sequence it falls. A bare number at the end of the list is the gap before the sequence repeats. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |portorclip is either the port to play on, or a clip from an earlier play-midi -- given a clip, what it is playing is replaced at the next boundary, staying on the port it is already on, and you get the same clip back. Given neither, it plays on the port set by set-default-port.'
+		'Plays a list of midi notes in a loop, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, and may carry a float tagged time saying where in the sequence it falls. Without a time it starts where the entry before it ended, so a list of notes carrying nothing but durations plays one after another. An entry with a duration and no note number is a rest: it takes up its time and sounds nothing, and a rest at the end is one way to put space before the repeat. A bare number at the end of the list is another. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |portorclip is either the port to play on, or a clip from an earlier play-midi -- given a clip, what it is playing is replaced at the next boundary, staying on the port it is already on, and you get the same clip back. Given neither, it plays on the port set by set-default-port.'
 	);
 
 	Builtin.aliasBuiltin('loop-midi on', 'play-midi');


### PR DESCRIPTION
Based on #376, independent of #377 and #378. Two commits.

**A note without a `time` starts where the entry before it ended.** So four notes
with nothing but durations are four quarter notes — and since duration already
defaults to one beat, four bare note numbers are too:

```
~(_play-midi [org](|
   [org](| #<`note`>60|)
   [org](| #<`note`>62|)
   [org](| #<`note`>64|)
   [org](| #<`note`>65|)|) @maudio_)
```

**An entry with a duration and no note number is a rest.** It takes up its time
and sounds nothing.

**The bare trailing number is gone.** A rest at the end does the same job, and it
reads as part of the sequence instead of as a special case for the last element.
A bare number in the list now gets a clear error rather than being taken apart as
though it were an org.

A note that *does* carry a `time` still wins, and the entries after it follow on
from there — so you can pin a phrase to a position and let the rest run
sequentially, and every existing fully-timed sequence behaves exactly as before.

One deliberate non-change: an entry with **neither** a note number nor a duration
is still an error rather than a rest of the default length. Otherwise a mistyped
`note` tag would quietly turn into silence instead of saying so.

Verified against a simulation of the timing at 120bpm:
- four 1-beat notes with no times land at 0, 0.5, 1.0, 1.5 s, length 2.0
- the same with no durations either gives identical output
- mixed eighths and quarters (0.5, 0.5, 1, 1 beats) land at 0, 0.25, 0.5, 1.0
- a 1-beat rest between two notes puts the second at 1.0 and the length at 1.5
- a trailing rest takes the length from 1.5 to 2.0 with the notes unmoved
- an explicit time of 4 beats mid-list moves that note to 2.0 and the next to 2.5
- a fully explicit-time sequence is unchanged
- a chord (three notes sharing an explicit time) works, and a following untimed
  note starts at the end of the last one read
- an empty entry, and an entry with a mistyped note tag, both error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT