### PR TITLE
[38] Let play-midi with an empty list give you an empty clip

### DIFF
--- a/server/namedsessions/shellraiser/setup
+++ b/server/namedsessions/shellraiser/setup
@@ -1,1 +1,1 @@
-v2:@setup-midi
+v2:;(|@setup-midi *"begin"(|*"let"(_@ports ?{2||listing midi ports}_) ~(_bind @maudio ~(_car ~(|filter @ports &"port"(|~(_jslog @port_) ~(|and ~(_equal $"M-Audio" @port.manufacturer_) ~(_equal $"output" @port.type_)|)|)|)_)_)|) (_$<`id`>"5293F8CAC098B93C78B45746BECBD0C203168A64ED4D9D5A69C02FDF4D4F7EEF" $<`manufacturer`>"M-Audio" $<`type`>"output" $<`name`>"M-Track MIDI 1" $<`version`>"ALSA library version 1.2.4" $<`state`>"connected" $<`connection`>"closed"_) ?{2||opening midi port} ;(|#;<`note`>45 #;<`duration`>1|) [nil]|)

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -281,10 +281,6 @@ function createMidiBuiltins() {
 				cursorSeconds = e.endsAtSeconds;
 				if (e.endsAtSeconds > nominalEnd) nominalEnd = e.endsAtSeconds;
 			}
-			if (events.length == 0) {
-				return constructFatalError('play-midi: nothing to play. Sorry!');
-			}
-
 			// The sequence is as long as its last entry nominally ends. Nominally:
 			// shortening a note to keep it clear of the next one is a note off
 			// sent early, not a shorter sequence. A rest at the end counts, which
@@ -292,7 +288,9 @@ function createMidiBuiltins() {
 			let lengthSeconds = nominalEnd;
 
 			// the clip already says it is midi, so this says what is in it
-			let what = events.length + ' note' + (events.length == 1 ? '' : 's');
+			let what = events.length == 0
+					? 'empty'
+					: events.length + ' note' + (events.length == 1 ? '' : 's');
 
 			if (clip) {
 				// Out at the boundary and back in at the same one, the way an
@@ -312,7 +310,7 @@ function createMidiBuiltins() {
 			clipStartedPlaying(clip, [ id ]);
 			return clip;
 		},
-		'Plays a list of midi notes in a loop, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, and may carry a float tagged time saying where in the sequence it falls. Without a time it starts where the entry before it ended, so a list of notes carrying nothing but durations plays one after another. An entry with a duration and no note number is a rest: it takes up its time and sounds nothing, and a rest at the end is how you put space before the sequence repeats. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |portorclip is either the port to play on, or a clip from an earlier play-midi -- given a clip, what it is playing is replaced at the next boundary, staying on the port it is already on, and you get the same clip back. Given neither, it plays on the port set by set-default-port.'
+		'Plays a list of midi notes in a loop, joining the global cycle at its next boundary, and returns a clip naming it. Each note is what send-midi-note takes, and may carry a float tagged time saying where in the sequence it falls. Without a time it starts where the entry before it ended, so a list of notes carrying nothing but durations plays one after another. An entry with a duration and no note number is a rest: it takes up its time and sounds nothing, and a rest at the end is how you put space before the sequence repeats. An empty list gives you an empty clip, which sounds nothing and holds its place until you pass it back in |portorclip with something to play. The loop plays for as long as something holds the clip: keep the clip and it loops, throw it away and it plays once, delete it and it stops at the end of the pass it is in. |portorclip is either the port to play on, or a clip from an earlier play-midi -- given a clip, what it is playing is replaced at the next boundary, staying on the port it is already on, and you get the same clip back. Given neither, it plays on the port set by set-default-port.'
 	);
 
 	Builtin.aliasBuiltin('loop-midi on', 'play-midi');

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -272,6 +272,16 @@ function makeMidiCycleMember(portId, events, lengthSeconds) {
 			// cycle before this one can still be sounding. Two cycles' worth is
 			// therefore everything that might need a note off, and keeping only
 			// that stops the list growing for as long as the loop runs.
+			/*
+			A sequence with no length would step the loop below by nothing at all
+			and never reach the end of the cycle. An empty clip has exactly that
+			length, and it only has to share the cycle with one real loop for the
+			cycle length to be greater than zero, so this is a hang rather than a
+			theoretical one.
+			*/
+			if (!(lengthSeconds > 0)) {
+				return;
+			}
 			let previous = member.thisCycle;
 			member.thisCycle = [];
 			// the sequence repeats within the cycle if the cycle is longer

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -446,6 +446,15 @@ function startCycleAt(startTime) {
 			delete cycleLoops[id];
 		}
 	}
+	/*
+	Counted before the length check, so that a clip holding nothing still gets
+	a pass and can be retired when nobody else wants it. An empty clip makes
+	the cycle length zero and stops the cycle, and a clip that never counts a
+	pass is never retired.
+	*/
+	for (let i = 0; i < playingClips.length; i++) {
+		playingClips[i].passes++;
+	}
 	let len = cycleLengthSeconds();
 	if (len <= 0) {
 		cycleRunning = false;
@@ -466,9 +475,6 @@ function startCycleAt(startTime) {
 		node.start(startTime);
 		node.stop(startTime + len);
 		loop.node = node;
-	}
-	for (let i = 0; i < playingClips.length; i++) {
-		playingClips[i].passes++;
 	}
 	let nextBoundary = startTime + len;
 	cycleNextBoundaryTime = nextBoundary;


### PR DESCRIPTION
Stacked on #380. Yes, this works — and it turned up a hang on the way.

```
~(_bind @slot ~(_play-midi [org](__)_)_)
```

gives you a clip that sounds nothing and holds its place, and later

```
~(_play-midi @myseq @slot_)
```

fills it, exactly as playing an empty wavetable does on the audio side. It still
needs a port that exists and is open — with `set-default-port` you just don't
have to name one.

The `play-midi: nothing to play` error is gone. A list of nothing but rests is
also fine now: that's a real silent sequence with a real length, not an empty
clip.

**The hang.** A midi sequence schedules itself with

```js
for (let base = 0; base < cycleLen; base += lengthSeconds) {
```

An empty sequence has `lengthSeconds` of 0, so that steps by nothing and never
reaches the end of the cycle. On its own an empty clip makes the cycle length
zero and the cycle stops, so it hides — but it only has to share the cycle with
**one** real loop for `cycleLen` to be greater than zero, and then the browser
locks up. Guarded now: no length, nothing to schedule.

**The clip that could never be retired.** `passes++` ran at the end of
`startCycleAt`, *after* the `len <= 0` early return. An empty clip makes the
length zero, so it never counted a pass — and `retireUnownedClips` skips anything
with zero passes. A discarded empty clip would have been owned by the audio
system for the rest of the session. Counting the pass before the length check
fixes it, and changes nothing for ordinary clips: the count still happens once
per tick, and retirement reads it on the following tick either way.

Verified with a simulation of the cycle state machine:
- the scheduling loop does not terminate at length 0 before the guard, returns
  immediately after, and is unchanged for real sequences (a 0.5s sequence still
  gets 4 passes in a 2s cycle, a 3s sequence gets 1)
- an empty clip on its own stops the cycle and stays in `cycleLoops`
- a real loop joining afterwards runs the cycle with the empty member still there
- replacing the empty clip with a 1s sequence retires the old member and installs
  the new one
- an empty clip nobody else holds counts a pass and is retired on the next tick
  that runs, rather than being owned forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT