### PR TITLE
[39] Make the stop button stop midi now rather than at the end of the pass

### DIFF
--- a/server/src/components/status_nav.jsx
+++ b/server/src/components/status_nav.jsx
@@ -27,7 +27,16 @@ const StatusNav = () => {
             {unsaved && <div className="unsaveddot" title="not saved yet"></div>}
             {playing &&
                 <div className="statusnavitem stopbutton" title="stop everything"
-                     onClick={() => { stopAllSound(); midiPanic(); stopAllLoops(); setPlaying(false); }}>
+                     onClick={() => {
+                         // midi first: it throws away messages the browser has
+                         // already been handed, and those are the ones that
+                         // would otherwise keep sounding after everything else
+                         // has stopped
+                         midiPanic();
+                         stopAllSound();
+                         stopAllLoops();
+                         setPlaying(false);
+                     }}>
                     {/* currentColor so the icon follows the theme token on the parent */}
                     <svg viewBox="0 0 8 9" width="8" height="9" aria-hidden="true">
                         <rect x="0" y="0" width="3" height="9" fill="currentColor"/>

--- a/server/src/midifunctions.js
+++ b/server/src/midifunctions.js
@@ -336,22 +336,44 @@ function anyMidiNotesSounding() {
 // never tracked.
 function midiPanic() {
 	if (!midi) return;
-	let channelsTouched = {};
+
+	/*
+	A sequence hands the browser a whole cycle of messages at once, each with
+	the time it should go out. Sending a note off now does not cancel any of
+	them -- the note on that was already queued arrives afterwards and the note
+	comes back. So the queue has to be thrown away first, and clear() is the
+	only thing that does it.
+
+	This drops what every sequence on the port had scheduled, which is why it
+	belongs to the stop button and not to any one clip stopping.
+	*/
+	for (let entry of midi.outputs) {
+		let out = entry[1];
+		if (out.clear) {
+			out.clear();
+		}
+	}
+
 	for (let k in soundingNotes) {
 		let n = soundingNotes[k];
-		channelsTouched[n.portId + ':' + n.channel] = n;
 		let out = midi.outputs.get(n.portId);
 		if (out) {
 			out.send([statusByte(0x80, n.channel), n.note, 0]);
 		}
 		delete soundingNotes[k];
 	}
-	for (let k in channelsTouched) {
-		let n = channelsTouched[k];
-		let out = midi.outputs.get(n.portId);
-		// cc 123, all notes off
-		if (out) {
-			out.send([statusByte(0xB0, n.channel), 123, 0]);
+
+	/*
+	Every channel, not only the ones soundingNotes knows about. Only
+	send-midi-note records anything there -- a play-midi sequence records
+	nothing, so going by that list meant a running sequence got no all notes
+	off at all, which is exactly the case the stop button is for.
+	*/
+	for (let entry of midi.outputs) {
+		let out = entry[1];
+		for (let channel = 1; channel <= 16; channel++) {
+			// cc 123, all notes off
+			out.send([statusByte(0xB0, channel), 123, 0]);
 		}
 	}
 }


### PR DESCRIPTION
Stacked on #381.

Audio already stopped immediately — `endAllLoops` calls `endLoops(ids, false)`,
which calls `node.stop()` on the source node there and then. Midi was the one
playing through, for two separate reasons.

**1. The messages were already queued in the browser.** A sequence hands over a
whole cycle at once with `out.send(bytes, when)`, each message carrying the time
it should go out. Sending a note off now cancels none of that — the note on that
was already queued arrives a moment later and the note comes back. The only thing
that drops the queue is `MIDIOutput.clear()`, so `midiPanic` now calls it on
every output before it does anything else.

That discards what *every* sequence on the port had scheduled, which is why it
belongs to the stop button and not to a single clip ending.

**2. The panic didn't know about sequences at all.** It walked `soundingNotes` to
decide which channels to send all-notes-off on. Only `send-midi-note` ever writes
to `soundingNotes` — a `play-midi` sequence records nothing there. So for a
running sequence `channelsTouched` came out empty and **no all-notes-off was sent
at all**, which is precisely the case the stop button exists for. It now sends
one on all 16 channels of every output.

The click handler runs `midiPanic()` first, since it's the one throwing away
messages that would otherwise sound after everything else had already stopped.

`out.clear` is feature-detected — it's in the Web MIDI spec and Chrome has it,
but a browser without it still gets the all-notes-off.

Not verified by ear, no midi hardware here. The audible test is a running
`play-midi` loop with long notes: before this, pressing stop left it going to the
boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT