### PR TITLE
[40] Add audio-channels

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -53,7 +53,7 @@ import {
   frequencyToNoteNum,
 } from "../wavetablefunctions.js";
 import { forEachSpectrum, hannWindow } from "../fft.js";
-import { loopPlay, abortPlayback, endLoops, clipStartedPlaying, togglePauseLoops, loopsArePlaying } from "../webaudio.js";
+import { loopPlay, abortPlayback, endLoops, clipStartedPlaying, togglePauseLoops, loopsArePlaying, getAudioChannelCount } from "../webaudio.js";
 import { constructClip } from "../nex/clip.js";
 import { Tag } from "../tag.js";
 import { ERROR_TYPE_INFO } from "../nex/eerror.js";
@@ -179,6 +179,22 @@ function createWavetableBuiltins() {
 
   // what it was called before it could do both
   Builtin.aliasBuiltin("loop-play", "play");
+
+  Builtin.createBuiltin(
+    "audio-channels",
+    [],
+    function $audioChannels(env, executionEnvironment) {
+      let n = getAudioChannelCount();
+      let r = constructOrg();
+      for (let i = 0; i < n; i++) {
+        r.appendChild(constructInteger(i));
+      }
+      // one short row rather than a tall column
+      r.setHorizontal();
+      return r;
+    },
+    "Every audio output this device has, as an org of channel numbers, which is exactly what play takes -- so play a wave across all of them by passing this straight in. Two things worth knowing: asking is what opens the audio device if nothing has made a sound yet, and the answer is fixed when that happens, so plugging in a different interface does not change it until you reload."
+  );
 
   Builtin.createBuiltin(
     "start-recording",

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -332,6 +332,13 @@ function getSourceFromBuffer(buffer, loop) {
 }
 
 // this plays immediately
+// How many outputs the device has, which is what the merger was built with.
+// Asking opens an audio device if nothing has yet.
+function getAudioChannelCount() {
+	maybeCreateAudioContext();
+	return channelMergerNode.numberOfInputs;
+}
+
 // Connecting past the merger's last input throws IndexSizeError from inside the
 // web audio api, which says nothing about channels.
 function checkChannelExists(channel) {
@@ -746,5 +753,5 @@ async function getFileAsBuffer(filepath) {
 }
 
 
-export { getAudioBufferFromData, loadSample, addLoop, getLoopPositionSamples, loopExists, clipStartedPlaying, pauseLoops, togglePauseLoops, loopsArePlaying, addCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
+export { getAudioBufferFromData, loadSample, addLoop, getAudioChannelCount, getLoopPositionSamples, loopExists, clipStartedPlaying, pauseLoops, togglePauseLoops, loopsArePlaying, addCycleMember, contextTimeToPerformanceTime, endLoops, endAllLoops, anyLoopsPlaying, nextCycleBoundary, maybeKillSound, getAuditionPositionSamples, isAnySoundPlaying, stopAllSound, startAuditioningBuffer, getFileAsBuffer, loopPlay, abortPlayback, startRecordingAudio, stopRecordingAudio }
 


### PR DESCRIPTION
Stacked on #382.

`audio-channels` gives back every audio output the device has, as an org of
channel numbers. That is exactly the shape `play` takes for its channels, so it
goes straight in:

```
~(_play @wt ~(_audio-channels_)_)
```

plays a wave across every output you have, whatever machine you are on. Count it
if the number is what you wanted.

The number was already known — `channelMergerNode.numberOfInputs`, set from
`ctx.destination.maxChannelCount` when the context is created (`webaudio.js:317`).
Until now the only way to see it was to ask for a channel that is not there and
read it out of the error.

Two things in the doc string, because both will surprise someone:

- **Asking is what opens the audio device**, if nothing has made a sound yet. The
  number comes from the context and there is no way to ask without creating one.
  Same concern as #345 about not making a context just to read its clock — the
  difference is that here the context genuinely is the thing being asked about.
- **The answer is fixed once that happens.** Plug in a different interface
  mid-session and it will not change until you reload. That is the same
  underlying limitation as #335, and this builtin makes it visible rather than
  causing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT