### PR TITLE
[41] Release the bound nex on scope cleanup, not the binding record

### DIFF
--- a/server/src/environment.js
+++ b/server/src/environment.js
@@ -109,10 +109,20 @@ class Environment {
 		heap.removeEnvReference(this.parentEnv);
 	}
 
+	/*
+	The binding record is not the thing that was bound. This released the
+	record, whose `references` is undefined -- so the zero check did not throw,
+	the decrement wrote NaN, the free test failed, and the reference on the nex
+	itself stayed put. Every argument to every command leaked one count,
+	silently, for as long as the session lasted.
+
+	Nothing consulted a reference count for a decision until clips did, so the
+	leak had no visible effect: heap.free simply almost never ran. It is the
+	reason a clip passed as an argument could never be retired.
+	*/
 	cleanUp() {
 		for (let name in this.symbols) {
-			let val = this.symbols[name];
-			heap.removeReference(val);
+			heap.removeReference(this.symbols[name].val);
 		}
 	}
 


### PR DESCRIPTION
Stacked on #383. **This is the bug behind "deleting a clip didn't stop it."**

`environment.js` bound values are held in a record `{name, val, packageName}`.
`bind()` releases the right thing:

```js
heap.removeReference(this.symbols[name].val);
```

`cleanUp()` released the record itself:

```js
let val = this.symbols[name];      // the record
heap.removeReference(val);         // ...not the nex
```

And it failed **silently**. A record has no `references` field, so `undefined == 0`
is false and the zero guard doesn't throw; `undefined--` writes `NaN`; `NaN == 0`
is false so nothing is freed. The reference on the actual nex is never removed.

Every builtin call pushes a scope, binds every argument into it, and
`builtinClosureExecutor` calls `scope.finalize()` — which drops the env to zero
and runs `cleanUp()`. So **every argument to every command leaked exactly one
count**, permanently.

## Why it looked intermittent

- `~(_play @wt_)` — the clip is the *result*, never an argument. Count is doc + audio
  = 2, delete takes it to 1, `references <= 1` holds, it retires at the boundary.
  This path always worked.
- `~(_play @wt @clip_)` — the replace workflow. Now the clip *is* an argument, so it
  leaks. Count 3, delete takes it to 2, `references <= 1` is never true, **the clip
  is never retired and deleting it does nothing.** Every re-evaluation adds another.

Same for anything else taking a clip: `toggle-playback`, `is-playing`, `play-midi`
with a clip.

## This is not from this session

`git log -L112,117:server/src/environment.js` dates it to f1ecd44, **July 2022**. It
was invisible because nothing consulted a reference count to make a decision, so
`heap.free` almost never ran. Clip retirement is the first code that reads the
count and acts on it, so it is the first thing to expose it.

## What to expect, and why this wants testing on its own

Fixing this means `heap.free` starts running on a great deal that has never been
freed in four years. `free()` calls `cleanupOnMemoryFree()`, which seven types
override — wavetable, closure, org, deferred value, deferred command, clip, and the
base. If any of those has a latent assumption that it is never called, this is when
it shows up. I would merge and exercise this one by itself rather than alongside
other changes.

Verified the arithmetic directly against the real guard: releasing the record
doesn't throw, leaves `references` as `NaN` on the record, and leaves the nex still
holding its count. Releasing `.val` frees correctly.

Found by a review agent I ran over the refcounting paths; it also refuted my own
guess that `sAttach` was the culprit, which was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT