### PR TITLE
[42] Do not free the same nex twice

### DIFF
--- a/server/src/heap.js
+++ b/server/src/heap.js
@@ -145,11 +145,29 @@ class Heap {
           "was subsequently added, so memory will be reallocated."
       );
       this.requestMem(obj.memUsed());
+      // it is not freed any more, and saying so is what lets it be freed again
+      // later -- otherwise the flag above would refuse forever
+      obj.wasFreed = false;
+      obj.memAllocated = true;
     }
     obj.references++;
   }
 
+  /*
+  Freeing twice takes the memory off twice, which walks usedSpace down to
+  negative and makes freeMem throw, and runs cleanupOnMemoryFree twice -- a
+  clip ended again, a wavetable told to drop samples it has already dropped, an
+  environment's reference removed a second time.
+
+  It happens because an action performs its delete before the undo buffer takes
+  hold of what was deleted. For that moment nothing at all holds the nex, so it
+  is freed there and then, and freed again later when the action falls out of
+  the buffer.
+  */
   free(obj) {
+    if (obj.wasFreed) {
+      return;
+    }
     this.freeMem(obj.memUsed());
     obj.cleanupOnMemoryFree();
     obj.memAllocated = false;


### PR DESCRIPTION
Stacked on #384, and it matters most *because* of #384 — that one makes `heap.free`
actually start running, which makes this path live.

`enqueueAndPerformAction` runs `action.doAction()` and only **then**
`retainActionNexes(action)` (`actions.js:115-117`). The comment says the ordering is
deliberate, because `doAction` is where an action captures what it holds. But it
means the document has already let go of the deleted nex before the undo buffer
takes hold of it. For that moment nothing holds it at all: `references` hits 0 with
`undoReferences` still 0, and `heap.removeReference` frees it there and then.

Then the undo reference is added. Later, when the action falls out of the 50-slot
buffer, `removeUndoReference` sees both counters at zero and frees **the same object
a second time**. `free` had no guard.

What that costs:

- `freeMem` subtracts `memUsed()` twice for one allocation, so `usedSpace` walks
  downward. When it crosses zero it **throws** — and since `releaseActionNexes` is
  the first statement of `enqueueAndPerformAction`, the throw lands before the
  action is stored, so the keystroke is dropped and the editor looks frozen.
- `cleanupOnMemoryFree` runs twice. `Closure`'s calls `heap.removeEnvReference`,
  which throws on its own when the env count is already zero. `Clip`'s ends the clip
  again. `Wavetable`'s drops samples already dropped. `DeferredCommand`'s cancels and
  finalizes a runInfo twice.

The guard is `if (obj.wasFreed) return`.

That needed one more thing to be correct: `addReference` already handles
resurrection (it re-requests the memory when a reference arrives on a freed object)
but left `wasFreed` set forever. With the new guard that would mean a resurrected
object could never be freed again, so resurrection now clears the flag. `wasFreed`
becomes "is currently freed" rather than "was ever freed", which is what both call
sites actually want.

**This does not fix the ordering**, only the double accounting. A nex is still freed
in the window between the delete and the retain, so `cleanupOnMemoryFree` still runs
once at a moment when undo is about to hold the object — which is why undoing the
deletion of a playing clip can give you back a clip marked STOPPED. That is a
separate change to when the undo buffer takes ownership, and I would rather do it on
its own than bury it here.

Found by a review agent; I verified the ordering, the missing guard, and the
`freeMem` throw by reading the code directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT