### PR TITLE
[43] Stop undo running off the ends of its buffer

### DIFF
--- a/server/src/actions.js
+++ b/server/src/actions.js
@@ -30,6 +30,13 @@ let nextPosition = 0;
 let queueBottom = 0;
 let queueTop = 0;
 let numItemsInQueue = 0;
+/*
+How far back undo has walked. Needed because the ring cannot say on its own:
+once the buffer is full, nextPosition and queueBottom are the same slot whether
+there are fifty things to undo or none, and undo walked straight past the
+bottom and undid already-undone actions a second time.
+*/
+let undosDeep = 0;
 
 function advance(queuePos) {
 	return (queuePos + 1) % levelsOfUndo;
@@ -110,8 +117,21 @@ function enqueueAndPerformAction(action) {
 			numItemsInQueue++;
 		}
 	} else {
+		/*
+		Acting after an undo abandons everything ahead of us. Those entries
+		describe a document that no longer exists, and redo would replay them
+		onto this one -- the comment above claimed overwriting the slot covered
+		it, but only this one slot is overwritten, not the rest of the tail.
+		*/
 		nextPosition = advance(nextPosition);
+		for (let p = nextPosition; p != queueTop; p = advance(p)) {
+			releaseActionNexes(actionStack[p]);
+			actionStack[p] = null;
+			numItemsInQueue--;
+		}
+		queueTop = nextPosition;
 	}
+	undosDeep = 0;
 	action.doAction();
 	// after doAction, which is where an action captures what it is holding
 	retainActionNexes(action);
@@ -123,6 +143,7 @@ function redo() {
 	if (nextPosition != queueTop) {
 		actionStack[nextPosition].doAction();
 		nextPosition = advance(nextPosition);
+		undosDeep--;
 		scheduleAutosave(systemState.getRoot());
 	} else {
 		console.log('cannot redo');
@@ -130,9 +151,17 @@ function redo() {
 }
 
 function undo() {
+	// nothing recorded yet, or undo has already reached the oldest thing the
+	// buffer still holds. Without this, the first ctrl-z of a session reads an
+	// empty slot and throws.
+	if (undosDeep >= numItemsInQueue) {
+		console.log('cannot undo');
+		return;
+	}
 	let pos = retreat(nextPosition);
-	if (actionStack[pos].canUndo()) {
+	if (actionStack[pos] && actionStack[pos].canUndo()) {
 		nextPosition = pos;
+		undosDeep++;
 		actionStack[nextPosition].undoAction();
 		scheduleAutosave(systemState.getRoot());
 	} else {


### PR DESCRIPTION
Stacked on #385. Three bugs in the undo queue's index arithmetic.

**1. `undo()` had no bounds check.** It computed `retreat(nextPosition)` and
dereferenced that slot immediately. Pressing ctrl-z as the first keystroke of a
session reads `actionStack[49]`, which is `undefined`, and throws a TypeError.
`keydispatcher.js:85` calls `undo()` with no guard of its own.

**2. Acting after an undo left the abandoned tail reachable.**
`enqueueAndPerformAction` only advances `queueTop` when `nextPosition == queueTop`,
so after undoing and then doing something new, the old entries above the new action
stay live and `redo()` will replay them. The comment claimed the discarded tail was
covered "since those slots are overwritten too" — only the single slot at
`nextPosition` is overwritten, not the rest.

Concretely with multiselect: enclose two nexes, ctrl-z twice, type a letter, ctrl-y.
Redo replays the `MultiSelectAction` with its cached `plan.from`/`plan.to`, which no
longer describe the same root children — so an org appears around the wrong range.
The plan is deliberately cached so redo doesn't recompute from a moved selection,
which is what makes the stale replay silently wrong rather than merely failing.

The tail is now released and truncated, which also frees the undo references those
entries were holding indefinitely.

**3. Undo walked past the bottom once the buffer was full.** With 50 entries,
`nextPosition` and `queueBottom` are the same slot whether there are fifty things to
undo or none — the ring can't distinguish full from empty. Undo kept going and
re-undid already-undone actions, which for a delete means re-inserting an
already-restored node. Depth is tracked explicitly now.

Verified by simulating the exact index arithmetic before and after, on five
scenarios:

| | before | after |
|---|---|---|
| ctrl-z as first keystroke | crash on empty slot | refused |
| A B M, undo×2, do N, redo | replays **M** from the dead branch | refused |
| ring of 4, do 6, undo×5 | 5th undo re-undoes a6 | refused |
| undo, redo, undo, undo, undo | — | B, B, A, then refused |
| A B C, undo×2, N, P, undo×4 | — | P, N, A, refused (B and C abandoned) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT