### PR TITLE
[44] Fix the multiselect undo guard that never fired

### DIFF
--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -1513,7 +1513,17 @@ class Manipulator {
 		if (plan.kind == 'select' || !org) return;
 		let root = systemState.getRoot();
 		let at = root.getIndexOfChild(org);
-		if (at == -1) return;
+		/*
+		getIndexOfChild answers -100 when the child is not there, not -1, so
+		this guard never fired. Going on with -100 detached every enclosed nex
+		from the org and then handed them to insertChildAt, which refuses a
+		negative index but has already had their reference removed -- so they
+		were freed instead of being put back. A wavetable lost its samples and
+		a clip was ended.
+
+		Anything negative, so a different sentinel cannot bring this back.
+		*/
+		if (at < 0) return;
 		let taken = this._takeChildren(org, 0, org.numChildren() - 1);
 		root.removeChildAt(at);
 		this._putChildren(root, taken, at);
@@ -1543,10 +1553,19 @@ class Manipulator {
 		return taken;
 	}
 
+	/*
+	The reference _takeChildren added is what holds a detached child while it is
+	in hand, and it is given up here because the new parent now holds it
+	instead. insertChildAt refuses an index outside the parent rather than
+	saying so, so giving it up regardless would free a child that never landed
+	anywhere -- which is destroying it, not moving it.
+	*/
 	_putChildren(parent, taken, at) {
 		for (let i = 0; i < taken.length; i++) {
 			parent.insertChildAt(taken[i], at + i);
-			heap.removeReference(taken[i].getNex());
+			if (taken[i].getParent() == parent) {
+				heap.removeReference(taken[i].getNex());
+			}
 		}
 	}
 


### PR DESCRIPTION
Stacked on #386. **This one is mine**, from the multiselect PR (#359).

`unapplyMultiSelect` guards with

```js
let at = root.getIndexOfChild(org);
if (at == -1) return;
```

but `RenderNode.getIndexOfChild` returns **`-100`** when the child is absent
(`rendernode.js:781` — literally `return -100;// I have reasons`). So the guard is
dead code, and undo carries on with `at = -100`:

- `_takeChildren(org, 0, ...)` detaches every enclosed nex from the org
- `root.removeChildAt(-100)` is a silent no-op
- `_putChildren(root, taken, -100)` calls `insertChildAt(child, -100 + i)`, which
  returns immediately on a negative index (`rendernode.js:806-808`) — **but the
  reference is given up anyway**

So the enclosed nexes end up attached to nothing with a count of zero, and are
freed. For a wavetable that means its samples are dropped; for a clip it means the
loop is ended. They vanish with no way back.

Reachable today: ctrl-shift-click two top-level nexes to wrap them in an org, ctrl-x
the org (cut doesn't go through the action stack at all), then ctrl-z.

Two changes:

- The guard is `at < 0`, so a different sentinel can't bring it back.
- `_putChildren` only gives up the reference when the child actually landed
  (`taken[i].getParent() == parent`). The reference `_takeChildren` added is what
  holds a detached child while it's in hand; giving it up is meant to hand ownership
  to the new parent, and doing that when nothing took ownership is destroying the
  child rather than moving it. That protects any future caller from the same class
  of data loss, not just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT