### PR TITLE
[46] Schedule midi against the audio clock, and keep that clock running

### DIFF
--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -317,6 +317,51 @@ function maybeCreateAudioContext() {
 	}
 }
 
+let silentKeepAlive = null;
+let warnedAboutMissingAudioClock = false;
+
+// getOutputTimestamp answers zeros until the context has produced output, so the
+// midi clock needs something playing whenever anything is in the cycle.
+function startSilentKeepAlive() {
+	maybeCreateAudioContext();
+	if (silentKeepAlive) return;
+	let buffer = ctx.createBuffer(1, Math.round(ctx.sampleRate), ctx.sampleRate);
+	let source = ctx.createBufferSource();
+	source.buffer = buffer;
+	source.loop = true;
+	let gain = ctx.createGain();
+	gain.gain.value = 0;
+	source.connect(gain);
+	gain.connect(ctx.destination);
+	source.start();
+	silentKeepAlive = source;
+}
+
+function audioClockIsReady() {
+	if (!ctx || ctx.state != 'running') return false;
+	let ts = ctx.getOutputTimestamp();
+	return !!(ts && ts.performanceTime > 0 && ts.contextTime != undefined);
+}
+
+// The first cycle waits for a clock to exist rather than starting against a
+// context time of zero, which would put every midi message in the past.
+function whenAudioClockIsReady(f) {
+	startSilentKeepAlive();
+	if (audioClockIsReady()) {
+		Promise.resolve().then(f);
+		return;
+	}
+	let tries = 0;
+	let check = function() {
+		if (audioClockIsReady() || ++tries > 200) {
+			f();
+			return;
+		}
+		window.setTimeout(check, 5);
+	};
+	window.setTimeout(check, 5);
+}
+
 function getAudioBufferFromData(data) {
   maybeCreateAudioContext();
 	let buffer = ctx.createBuffer(1, data.length, SAMPLE_RATE);
@@ -532,7 +577,7 @@ function addCycleMember(loop) {
 	*/
 	if (!cycleRunning) {
 		cycleRunning = true;
-		Promise.resolve().then(function() {
+		whenAudioClockIsReady(function() {
 			startCycleAt(ctx.currentTime);
 		});
 	}
@@ -656,17 +701,14 @@ so the output buffer delay is already in the answer.
 */
 function contextTimeToPerformanceTime(contextTime) {
 	let ts = ctx.getOutputTimestamp();
-	/*
-	A context that has not produced any output yet answers with zeros rather
-	than with nothing, and zero is a real performanceTime as far as the test
-	below is concerned. Anchoring to it puts every midi message at its context
-	time in milliseconds, which is however long the page has been open in the
-	past -- so the browser sends the whole sequence at once, immediately.
-	*/
+	// A context that has not produced output answers with zeros, not with nothing.
 	if (ts && ts.contextTime != undefined && ts.performanceTime > 0) {
 		return ts.performanceTime + (contextTime - ts.contextTime) * 1000;
 	}
-	// no timestamp available: fall back to the current time plus the gap
+	if (!warnedAboutMissingAudioClock) {
+		warnedAboutMissingAudioClock = true;
+		console.log('vodka: no audio clock, midi timing will drift from audio');
+	}
 	return performance.now() + (contextTime - ctx.currentTime) * 1000;
 }
 

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -310,6 +310,11 @@ function maybeCreateAudioContext() {
 		channelMergerNode = ctx.createChannelMerger(ctx.destination.maxChannelCount);
 		channelMergerNode.connect(ctx.destination);
 	}
+	// a suspended context's clock does not advance, and everything in the cycle
+	// is scheduled against that clock
+	if (ctx.state == 'suspended') {
+		ctx.resume();
+	}
 }
 
 function getAudioBufferFromData(data) {
@@ -651,7 +656,14 @@ so the output buffer delay is already in the answer.
 */
 function contextTimeToPerformanceTime(contextTime) {
 	let ts = ctx.getOutputTimestamp();
-	if (ts && ts.contextTime != undefined && ts.performanceTime != undefined) {
+	/*
+	A context that has not produced any output yet answers with zeros rather
+	than with nothing, and zero is a real performanceTime as far as the test
+	below is concerned. Anchoring to it puts every midi message at its context
+	time in milliseconds, which is however long the page has been open in the
+	past -- so the browser sends the whole sequence at once, immediately.
+	*/
+	if (ts && ts.contextTime != undefined && ts.performanceTime > 0) {
 		return ts.performanceTime + (contextTime - ts.contextTime) * 1000;
 	}
 	// no timestamp available: fall back to the current time plus the gap


### PR DESCRIPTION
Stacked on #388. This is the "only the last note plays, slowly" bug, and then the
right fix for it.

## What was wrong

```
MIDI start: cycleLen 4.000 lengthSeconds 4.000 events 6 startTime 0.000 now 15979.7
   send note 41 ch 1 at 0.000 -> onAt 0.0 (-15980.3ms from now)
   send note 38 ch 1 at 1.000 -> onAt 1000.0 (-14981.1ms from now)
   ...
```

Every message was timestamped ~16 seconds **in the past**, so the browser sent the
whole sequence at once — six note-on/note-off pairs back to back in a single burst —
then waited a cycle and did it again. Hence one audible note and a long gap.

`ctx.getOutputTimestamp()` answers `{contextTime: 0, performanceTime: 0}` until the
context has produced output, and `0 != undefined` is true, so the guard anchored
everything to zero.

Parsing was never involved — the sequence parsed correctly throughout, and the
note-off shortening was right too (995ms on the 1s notes, 495ms on the 0.5s ones).

## The fix

Requiring `performanceTime > 0` reaches the `performance.now()` fallback, and that
worked — but it is the wrong answer, because it is a **second clock**. Start a midi
sequence, start an audio loop later, and they would drift apart, which defeats the
point of a shared cycle.

So instead the audio clock is made to exist:

- **A silent keep-alive.** One second of silence, looping, through a gain of zero,
  started as soon as anything joins the cycle. The context keeps producing output,
  so `getOutputTimestamp` always has a real anchor and midi and audio are always
  scheduled against the same clock whichever starts first.
- **The first cycle waits for the clock** instead of firing on the next microtask
  against a context time of zero. `ctx.resume()` is async, so there was no way to be
  correct without waiting.
- **A suspended context is resumed** — its clock does not advance at all.
- **The fallback stays as a warned last resort.** It should never be reached now; if
  it is, the console says `no audio clock, midi timing will drift from audio`.

## Cost

Once anything has played, the audio device stays open for the session, because the
silent source never stops. That is the price of a clock that is always there.

## Not from this session

`contextTimeToPerformanceTime` has been this way since the midi cycle was built. It
only bites when a midi loop is the first thing to touch the audio system on a page,
which is exactly what testing midi on its own does — play any audio first and the
context has a valid anchor, which is why it worked before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT