### PR TITLE
[47] Put cut and paste on the undo stack

### DIFF
--- a/server/src/actions.js
+++ b/server/src/actions.js
@@ -412,6 +412,66 @@ class ChangeSelectedNodeAction extends Action {
 	}
 }
 
+/*
+Cut and paste change the document, so they belong on the undo stack like any
+other change. Without that, undo after a paste reaches back to whatever action
+came before it and undoes that instead, against a document it no longer
+describes.
+*/
+class CutAction extends Action {
+	constructor(actionName) {
+		super(actionName);
+	}
+
+	canUndo() {
+		return !!this.parentOfCutNode;
+	}
+
+	doAction() {
+		let node = systemState.getGlobalSelectedNode();
+		let parent = node.getParent();
+		let index = parent ? parent.getIndexOfChild(node) : -1;
+		let insertionMode = node.getInsertionMode();
+		if (!manipulator.doCut()) {
+			return;
+		}
+		this.cutNode = node;
+		this.parentOfCutNode = parent;
+		this.index = index;
+		this.savedInsertionMode = insertionMode;
+	}
+
+	undoAction() {
+		if (!this.parentOfCutNode || this.index < 0) return;
+		this.parentOfCutNode.insertChildAt(this.cutNode, this.index);
+		this.cutNode.setSelected();
+		this.cutNode.setInsertionMode(this.savedInsertionMode);
+	}
+}
+
+class PasteAction extends Action {
+	constructor(actionName) {
+		super(actionName);
+	}
+
+	canUndo() {
+		return !!this.pastedNode;
+	}
+
+	doAction() {
+		this.selectedBefore = systemState.getGlobalSelectedNode();
+		this.insertionModeBefore = this.selectedBefore.getInsertionMode();
+		this.pastedNode = manipulator.doPaste();
+	}
+
+	undoAction() {
+		if (!this.pastedNode) return;
+		manipulator.removeNex(this.pastedNode);
+		this.selectedBefore.setSelected();
+		this.selectedBefore.setInsertionMode(this.insertionModeBefore);
+	}
+}
+
 class LegacyKeyResponseFunctionAction extends Action {
 	constructor(actionName) {
 		super(actionName);
@@ -779,6 +839,11 @@ function actionFactory(actionName, eventName) {
 			return new LineBreakAction(actionName);
 
 		// Legacy ones below, these can't be undone
+
+		case 'cut':
+			return new CutAction(actionName);
+		case 'paste':
+			return new PasteAction(actionName);
 
 		case 'unroll':
 			return new UnrollAction(actionName);

--- a/server/src/keydispatcher.js
+++ b/server/src/keydispatcher.js
@@ -91,11 +91,12 @@ class KeyDispatcher {
 				evaluateAndKeep(rn)
 			}
 		} else if (this.getClipboardCommand(eventName) == 'cut') {
-			manipulator.doCut();
+			enqueueAndPerformAction(actionFactory('cut'));
 		} else if (this.getClipboardCommand(eventName) == 'copy') {
+			// copy does not change the document, so there is nothing to undo
 			manipulator.doCopy();
 		} else if (this.getClipboardCommand(eventName) == 'paste') {
-			manipulator.doPaste();
+			enqueueAndPerformAction(actionFactory('paste'));
 		} else if (eventName == 'Escape' && !systemState.getGlobalSelectedNode().usingEditor()) {
 			this.toggleGlobalExplodedMode();
 		} else {

--- a/server/src/manipulator.js
+++ b/server/src/manipulator.js
@@ -1840,7 +1840,9 @@ class Manipulator {
 		}
 		let x = systemState.getGlobalSelectedNode();
 		this.selectPreviousSibling() || this.selectParent();		
-		this.removeNex(x);
+		// false when it was not in the tree to begin with, which undo has to
+		// know about or it will put back something that never left
+		return this.removeNex(x);
 	}
 
 	// used in keydispatcher.js
@@ -1917,6 +1919,7 @@ class Manipulator {
 	}
 
 	// used in keydispatcher.js
+	// returns the node it pasted, so it can be taken out again
 	doPaste() {
 		let s = systemState.getGlobalSelectedNode();
 		try {
@@ -1936,7 +1939,8 @@ class Manipulator {
 					this.insertAsFirstChild(newNex);
 					this.selected().setInsertionMode(CLIPBOARD_INSERTION_MODE);
 					break;
-			}			
+			}
+			return this.selected();
 		} catch (e) {
 			if (Utils.isFatalError(e)) {
 				Utils.beep();


### PR DESCRIPTION
Stacked on #389.

Cut and paste both change the document and neither was recorded, so undo after a
paste reached back to whatever action came *before* it and undid that instead —
against a document that action no longer described. The phantom extra nex is that
older action putting something back.

`manipulator.doCut()` and `doPaste()` have been called straight from the key
dispatcher since **dfeaae4, January 2020**, and `manipulator.js` has never called
`enqueueAndPerformAction` on any branch. So this is long-standing rather than a
regression — but it is only visible when the previous action's undo happens to
conflict with the changed document, which is why it can go years without being
noticed.

- `CutAction` saves the node, its parent, its index and its insertion mode, and puts
  them back on undo.
- `PasteAction` remembers what it pasted and takes it out again.
- `doCut` now reports whether it actually removed anything, so undo cannot put back
  something that never left.
- `doPaste` returns the node it pasted.
- Copy is untouched — it does not modify the document.

**Two things this does not fix**, both already known:

- `redo()` re-runs `doAction()` without re-retaining, so redoing a paste creates a
  new node while `heldNexes` still points at the old one. That is the refcount
  review's finding 3, and paste is now another way to reach it.
- Actions that undo against whatever is selected *now* rather than a node they
  saved — `EvaluateAndReplaceAction`, `EditorContentChangeAction` and friends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT