### PR TITLE
[50] Let repeat fill a length, not just a count

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -2208,25 +2208,41 @@ function createWavetableBuiltins() {
 
   Builtin.createBuiltin(
     "repeat",
-    ["wt_", "reps#?"],
+    ["wt_", "reps#%?"],
     function $repeat(env, executionEnvironment) {
       let wt = env.lb("wt");
-      let times = 1;
-      if (times != UNBOUND) {
-        times = env.lb("reps").getTypedValue();
-      }
+      let reps = env.lb("reps");
       let wtdur = wt.getDuration();
-      let dur = wtdur * times;
+      if (wtdur < 1) {
+        return constructFatalError("repeat: there is nothing to repeat. Sorry!");
+      }
+
+      // tagged with a timebase it is the length to fill, untagged it is how
+      // many times round
+      let dur;
+      if (reps == UNBOUND) {
+        dur = wtdur;
+      } else if (explicitTimebase(reps)) {
+        dur = convertTimeToSamples(reps);
+      } else {
+        dur = Math.round(wtdur * reps.getTypedValue());
+      }
+      if (!(dur >= 1)) {
+        return constructFatalError("repeat: that is not long enough to hold anything. Sorry!");
+      }
+      if (dur > STRETCH_MAX_OUTPUT) {
+        return constructFatalError("repeat: that would be too long to hold. Sorry!");
+      }
+
       let r = constructWavetable(dur);
       let data = r.getData();
-
       for (let i = 0; i < dur; i++) {
         data[i] = wt.valueAtSample(i % wtdur);
       }
       r.init();
       return r;
     },
-    "Repeats (loops) a sample a number of times exactly equal to |reps."
+    "Repeats wt| |reps times over. Tag |reps with a timebase (nn, secs, hz, b, samps) and it is the length to fill instead, so a one cycle wave repeated for a beat lasts exactly a beat, with the last time round cut off wherever it lands. Without |reps you get one copy."
   );
 
   Builtin.createBuiltin(


### PR DESCRIPTION
Stacked on #392.

```
~(_repeat ~(_squarewave %220 hz_) %1 b_)
```

A one-cycle square, repeated to last exactly one beat. Tag `reps` with a timebase
and it is the length to fill; the last time round is cut off wherever it lands,
which is what you want for a tone that has to end on the beat rather than at a
cycle boundary.

Untagged it still means how many times over, and it takes a float now rather than
an integer, so two and a half copies is sayable.

**It also fixes a plain bug.** `repeat` with no `reps` never worked:

```js
let times = 1;
if (times != UNBOUND) {          // times is 1, so always true
  times = env.lb("reps").getTypedValue();
}
```

The guard tests `times`, which was assigned `1` the line before and is therefore
never `UNBOUND`, so it always went on to read an argument that was not there. The
optional argument was optional in the parameter list only.

Verified: one cycle of a 220hz square is 218 samples at 48k, and

- no reps gives 218
- `4` gives 872, `2.5` gives 545
- `1 b` gives 24000 — half a second at 120bpm — which is 110.09 cycles, the last
  one cut short
- `4 b` gives 96000
- every sample matches the source at `i % cycle`, so nothing shifts at the seams

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT