### PR TITLE
[52] Do not build a wavetable with no samples

### DIFF
--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -1440,10 +1440,12 @@ function createWavetableBuiltins() {
           `resample-by: result wavetable too long! Must be less than ${maxdur} samples.`
         );
       }
-      if (resultDuration <= 0) {
-        // is it possible to get here?
+      // it is possible to get here: resampling by more than the wave is long
+      // leaves a fraction of a sample
+      resultDuration = Math.round(resultDuration);
+      if (resultDuration < 1) {
         return constructFatalError(
-          `resample-by: result wavetable too short (would be zero-length).`
+          "resample-by: that leaves less than one sample. Sorry!"
         );
       }
 

--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -1505,6 +1505,17 @@ function constructWavetable(initSize) {
 	if (!initSize) {
 		initSize = 256;
 	}
+	/*
+	Float32Array truncates a fractional length rather than refusing it, so a
+	size below one becomes a wave with no samples -- and nothing below one is
+	falsy, so the test above lets it through. That wave cannot be given an
+	audio buffer, which is where it finally fails, a long way from whoever
+	asked for it.
+	*/
+	initSize = Math.floor(initSize);
+	if (initSize < 1) {
+		initSize = 1;
+	}
 	let sizeRequired = heap.sizeWavetable() + initSize * heap.incrementalSizeWavetable();
 	if (!heap.requestMem(sizeRequired)) {
 		throw constructFatalError(`OUT OF MEMORY: cannot allocate Wavetable.

--- a/server/src/webaudio.js
+++ b/server/src/webaudio.js
@@ -364,7 +364,10 @@ function whenAudioClockIsReady(f) {
 
 function getAudioBufferFromData(data) {
   maybeCreateAudioContext();
-	let buffer = ctx.createBuffer(1, data.length, SAMPLE_RATE);
+	// createBuffer throws on nothing at all, and one silent frame sounds like
+	// what a wave with no samples should sound like
+	let frames = data.length > 0 ? data.length : 1;
+	let buffer = ctx.createBuffer(1, frames, SAMPLE_RATE);
 	let chan = buffer.getChannelData(0);
 	chan.set(data);	
 	return buffer;


### PR DESCRIPTION
Stacked on #394. This is the `createBuffer … number of frames provided (0)` crash.

`Float32Array` **truncates** a fractional length rather than refusing it:

```
new Float32Array(0.5).length   ->  0
!0.5                           ->  false
```

So a size below one becomes a wave with no samples, and since nothing below one is
falsy, `constructWavetable`'s existing `if (!initSize)` test lets it straight
through. It then fails in `createBuffer`, a long way from whoever asked for it,
which is why the stack looked unrelated to what you ran.

**`resample-by` is how you reach it.** It computes
`oldDuration * (1 / |scaleFactor|)`, a float, and the moment the factor is larger
than the wave is long that is a fraction of a sample. The existing
`if (resultDuration <= 0)` guard — with its "is it possible to get here?" comment —
never fires, because 0.33 is greater than zero.

A 100 sample wave:

| resample by | length | before | after |
|---|---|---|---|
| 2 | 50.000 | 50 samples | 50 samples |
| 50 | 2.000 | 2 samples | 2 samples |
| 100 | 1.000 | 1 sample | 1 sample |
| 300 | 0.333 | **crash** | clear error |
| 1000 | 0.100 | **crash** | clear error |

Three changes, narrowest first:

- `resample-by` rounds the result and says so when there is less than a sample left
- `constructWavetable` floors its size and will not build anything shorter than one
  sample, whatever the caller passes
- `getAudioBufferFromData` uses one silent frame rather than none, so no other path
  can throw there either

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT