### PR TITLE
[53] Say so when a clip did not survive a refresh

### DIFF
--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -237,6 +237,11 @@ function createMidiBuiltins() {
 			let arg = env.lb('portorclip');
 			let clip = null;
 			let portNex = UNBOUND;
+			if (Utils.isNil(arg)) {
+				// a clip is never saved, so a refresh leaves a nil behind
+				return constructFatalError(
+						'play-midi: that clip is gone, a refresh does not keep them. Sorry!');
+			}
 			if (arg != UNBOUND) {
 				if (Utils.isClip(arg)) {
 					if (arg.getKind() != 'midi loop') {

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -89,6 +89,7 @@ function createWavetableBuiltins() {
     ["clip"],
     function $togglePlayback(env, executionEnvironment) {
       let clip = env.lb("clip");
+      if (Utils.isNil(clip)) return goneClipError("toggle-playback");
       if (!Utils.isClip(clip)) {
         return constructFatalError("toggle-playback: not a clip. Sorry!");
       }
@@ -111,6 +112,7 @@ function createWavetableBuiltins() {
     ["clip"],
     function $isPlaying(env, executionEnvironment) {
       let clip = env.lb("clip");
+      if (Utils.isNil(clip)) return goneClipError("is-playing");
       if (!Utils.isClip(clip)) {
         return constructFatalError("is-playing: not a clip. Sorry!");
       }
@@ -118,6 +120,16 @@ function createWavetableBuiltins() {
     },
     "True if |clip is making sound: still in the cycle, and not silenced by toggle-playback."
   );
+
+  /*
+  A clip is never written to a file, so an expression that held one holds a nil
+  after a refresh. Saying so beats complaining about whatever a nil looks like
+  to the argument that was expecting a clip.
+  */
+  function goneClipError(who) {
+    return constructFatalError(
+        who + ": that clip is gone, a refresh does not keep them. Sorry!");
+  }
 
   // Channels are 1-based to the user, the way audio hardware numbers them.
   function toChannelIndexes(numbers, who) {
@@ -164,6 +176,7 @@ function createWavetableBuiltins() {
         // heard. Nothing here has to know how a loop is put together.
         endLoops(clip.getIds(), true /* at the cycle end */);
       } else if (arg != UNBOUND) {
+        if (Utils.isNil(arg)) return goneClipError("play");
         channelnumbers = [];
         if (Utils.isNexContainer(arg)) {
           for (let i = 0; i < arg.numChildren(); i++) {


### PR DESCRIPTION
Stacked on #395.

Clips are runtime-only and serialize as `[nil]`, so after a refresh an expression
that held one holds a nil. Passing that back to `play` fell into the channels
branch, the nil was read as a channel number, and you got

```
play: there is no channel undefined. Sorry!
```

which is about the argument's shape rather than about what happened. Now:

```
play: that clip is gone, a refresh does not keep them. Sorry!
```

Same for `play-midi`, `toggle-playback` and `is-playing`, all of which took a clip
and would otherwise complain that a nil is not a port, or not a clip.

Nothing else changes — this is only the message. The behaviour you found is
correct and by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT