### PR TITLE
[54] Lex an argument spec instead of picking it apart by hand

### DIFF
--- a/server/src/argevaluator.js
+++ b/server/src/argevaluator.js
@@ -153,7 +153,8 @@ class ArgEvaluator {
     let isAllowedType = false;
     for (let j = 0; j < allowedTypes.length; j++) {
       let expectedType = allowedTypes[j];
-      let typeChecksOut = ArgEvaluator.ARG_VALIDATORS[expectedType](argnex);
+      let validator = ArgEvaluator.ARG_VALIDATORS[expectedType];
+      let typeChecksOut = validator ? validator(argnex) : false;
       if (typeChecksOut) {
         isAllowedType = true;
         break;
@@ -350,6 +351,7 @@ ArgEvaluator.ARG_VALIDATORS = {
   Lambda: (arg) => arg.getTypeName() == "-lambda-",
   Closure: (arg) => arg.getTypeName() == "-closure-",
   Contract: (arg) => arg.getTypeName() == "-contract-",
+  Clip: (arg) => arg.getTypeName() == "-clip-",
 };
 
 export {

--- a/server/src/builtins/contractbuiltins.js
+++ b/server/src/builtins/contractbuiltins.js
@@ -33,7 +33,7 @@ function createContractBuiltins() {
 
 	Builtin.createBuiltin(
 		'sign for',
-		[ 'contractк', 'tag$' ],
+		[ 'contractκ', 'tag$' ],
 		function $signFor(env, executionEnvironment) {
 			// TODO: type check
 			let tagname = env.lb('tag');

--- a/server/src/builtins/midibuiltins.js
+++ b/server/src/builtins/midibuiltins.js
@@ -223,7 +223,7 @@ function createMidiBuiltins() {
 
 	Builtin.createBuiltin(
 		'play-midi',
-		[ 'seq()', 'portorclip?' ],
+		[ 'seq()', 'portorclip()μ?' ],
 		function $playMidi(env, executionEnvironment) {
 			let list = env.lb('seq');
 

--- a/server/src/builtins/wavetablebuiltins.js
+++ b/server/src/builtins/wavetablebuiltins.js
@@ -86,7 +86,7 @@ function createWavetableBuiltins() {
 
   Builtin.createBuiltin(
     "toggle-playback",
-    ["clip"],
+    ["clipμ"],
     function $togglePlayback(env, executionEnvironment) {
       let clip = env.lb("clip");
       if (Utils.isNil(clip)) return goneClipError("toggle-playback");
@@ -109,7 +109,7 @@ function createWavetableBuiltins() {
 
   Builtin.createBuiltin(
     "is-playing",
-    ["clip"],
+    ["clipμ"],
     function $isPlaying(env, executionEnvironment) {
       let clip = env.lb("clip");
       if (Utils.isNil(clip)) return goneClipError("is-playing");
@@ -146,7 +146,7 @@ function createWavetableBuiltins() {
 
   Builtin.createBuiltin(
     "play",
-    ["wt_", "channelsorclip?"],
+    ["wt_", "channelsorclip#%()μ?"],
     function $loopPlay(env, executionEnvironment) {
       let wt = env.lb("wt");
 

--- a/server/src/paramlexer.js
+++ b/server/src/paramlexer.js
@@ -1,0 +1,152 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+One argument's spec, lexed. The grammar is regular -- nothing nests and nothing
+recurses -- so this is a lexer and there is no parser to go with it:
+
+    param := '_'? '='? name? type* '?'? '...'?
+
+The type section is a union built one token at a time, which is why #% means
+"integer or float". It is unordered and repeats are harmless: %# says the same
+thing as #%.
+
+Underscore is three things at once -- the skipeval prefix, a legal character
+inside a name, and the wavetable type -- and position is what tells them apart.
+A name may contain an underscore but may not end in one, which is the rule that
+makes _wt_ come out as skipeval, name "wt", type Wavetable rather than any of
+the other readings.
+
+A spec with no name at all is a return value. parseString marks those with a
+leading backslash before they get here.
+
+Every character has to be claimed by a rule. Anything left over is a spec that
+does not mean what it looks like, and the caller is told rather than being
+handed a type that silently matches nothing.
+*/
+
+// longest first, so a two character token is never mistaken for its first half
+const TYPE_TOKENS = [
+	['()', 'NexContainer'],
+	['!', 'Bool'],
+	['~', 'Command'],
+	['*', 'Deferred'],
+	['$', 'EString'],
+	['@', 'ESymbol'],
+	['%', 'Float'],
+	['#', 'Integer'],
+	['_', 'Wavetable'],
+	['^', 'Instantiator'],
+	['&', 'Closure'],
+	['κ', 'Contract'],
+	['μ', 'Clip'],
+];
+
+// may hold an underscore, may not end in one
+const NAME_RE = /^[a-zA-Z0-9_-]*[a-zA-Z0-9-]/;
+
+function lexParam(spec) {
+	let rest = spec;
+	let tokens = [];
+	let out = {
+		tokens: tokens,
+		error: null,
+		isReturnValue: false,
+		name: '',
+		typeString: '',
+		types: [],
+		skipeval: false,
+		skipactivate: false,
+		variadic: false,
+		optional: false,
+		convert: true,
+	};
+	let take = function(kind, text, extra) {
+		let t = { kind: kind, text: text };
+		if (extra) t.type = extra;
+		tokens.push(t);
+		rest = rest.substring(text.length);
+	};
+
+	if (rest.startsWith('\\')) {
+		out.isReturnValue = true;
+		take('returnvalue', '\\');
+	}
+	if (rest.startsWith('_')) {
+		out.skipeval = true;
+		take('skipeval', '_');
+	}
+	if (rest.startsWith('=')) {
+		out.convert = false;
+		take('noconvert', '=');
+	}
+
+	let nameMatch = NAME_RE.exec(rest);
+	if (nameMatch) {
+		out.name = nameMatch[0];
+		take('name', nameMatch[0]);
+	}
+
+	for (;;) {
+		if (rest.startsWith(',')) {
+			// kept because parseParam has always understood it, though nothing uses it
+			out.skipactivate = true;
+			take('skipactivate', ',');
+			continue;
+		}
+		let matched = null;
+		for (let i = 0; i < TYPE_TOKENS.length; i++) {
+			if (rest.startsWith(TYPE_TOKENS[i][0])) {
+				matched = TYPE_TOKENS[i];
+				break;
+			}
+		}
+		if (!matched) break;
+		out.types.push(matched[1]);
+		out.typeString += matched[0];
+		take('type', matched[0], matched[1]);
+	}
+
+	if (rest.startsWith('?')) {
+		out.optional = true;
+		take('optional', '?');
+	}
+	if (rest.startsWith('...')) {
+		out.variadic = true;
+		take('variadic', '...');
+	}
+
+	if (rest != '') {
+		out.error = 'cannot make sense of "' + rest + '" in the argument "' + spec + '"';
+		return out;
+	}
+	if (out.optional && out.variadic) {
+		out.error = 'the argument "' + spec + '" is both optional and variadic';
+		return out;
+	}
+	if (out.name == '' && out.types.length == 0 && !out.isReturnValue) {
+		out.error = 'the argument "' + spec + '" has neither a name nor a type';
+		return out;
+	}
+	return out;
+}
+
+function typeUnionOf(types) {
+	return types.length == 0 ? '*' : types.join('|');
+}
+
+export { lexParam, typeUnionOf, TYPE_TOKENS }

--- a/server/src/paramparser.js
+++ b/server/src/paramparser.js
@@ -29,6 +29,7 @@ variadics are packaged up inside a list of some type (maybe a word)
 */
 
 import { BUILTIN_ARG_PREFIX } from "./environment.js";
+import { lexParam, typeUnionOf } from "./paramlexer.js";
 import { experiments } from "./globalappflags.js";
 
 class ParamParser {
@@ -47,7 +48,7 @@ class ParamParser {
   }
 
   parseString(str) {
-    let hasReturnVal = /^[~!@#$%^𝒞&*?(),.]+/.test(str);
+    let hasReturnVal = /^[~!@#$%^&*?(),.\u03ba\u03bc]+/.test(str);
     let a = str.split(" ");
     if (hasReturnVal) {
       a[0] = "\\" + a[0];
@@ -75,79 +76,34 @@ class ParamParser {
     }
   }
 
+  /*
+  The spec is lexed rather than picked apart by hand. A builtin's spec is a
+  constant written here in the source, so one that does not lex is a mistake to
+  be shouted about at startup; a lambda's is being typed by someone and is
+  half-finished most of the time, so that one just says no for now.
+  */
   parseParam(s) {
-    let originals = s;
-    let skipeval = false;
-    let variadic = false;
-    let optional = false;
-    let skipactivate = false;
-    let convert = true;
-    // we re-parse every time the user changes the args
-    // when they are editing the args -- this means that there are transition states
-    // while they are typing when the args may not make sense and it's just okay.
-    if (s.charAt(0) == "_") {
-      skipeval = true;
-      s = s.substring(1);
-      if (s == "") return null;
+    let lexed = lexParam(s);
+    if (lexed.error) {
+      if (this.isBuiltin) {
+        throw new Error("bad builtin argument spec: " + lexed.error);
+      }
+      return null;
     }
-
-    if (s.charAt(0) == "=") {
-      convert = false;
-      s = s.substring(1);
-      if (s == "") return null;
-    }
-
-    if (s.length >= 3 && s.endsWith("...")) {
-      variadic = true;
-      s = s.substring(0, s.length - 3);
-      if (s == "") return null;
-    }
-    if (s.endsWith("?")) {
-      optional = true;
-      s = s.substring(0, s.length - 1);
-      if (s == "") return null;
-    }
-    let groups = s.match(/([a-zA-Z0-9_-]*[a-zA-Z0-9-])(.*)/);
-    let typeString;
-    if (groups) {
-      typeString = groups[2];
-      s = groups[1];
-    } else {
-      // No identifier characters at all, so the whole token is a bare type code
-      // with no name. That's how a return value is declared: parseString() spots
-      // a leading type code and marks it with a backslash, so "#% lst()" means
-      // "returns an integer or float, takes a container called lst". Keep the
-      // backslash as the name, because parse() routes on it and lambda.js strips
-      // it back off when rebuilding the lambda's display text.
-      let isReturnValue = (s.charAt(0) == "\\");
-      typeString = isReturnValue ? s.substring(1) : s;
-      s = isReturnValue ? "\\" : "";
-    }
-
-    let typeValidator = this.getTypeValidator(typeString);
-    if (typeString == ",") {
-      // is this deprecated?
-      skipactivate = true;
-    }
-    // why not if '*'?
-    // if (typeValidator != "*") {
-    //   s = s.substring(0, s.length - typeString.length);
-    //   if (s == "") return null;
-    // }
+    let name = lexed.isReturnValue ? "\\" : lexed.name;
     if (this.isBuiltin) {
-      s = BUILTIN_ARG_PREFIX + s;
+      name = BUILTIN_ARG_PREFIX + name;
     }
-    // TODO: make this a more solid data type with a memUsed function etc.
     return {
-      name: s,
-      debugName: originals,
-      typeString: typeString,
-      type: typeValidator,
-      skipeval: skipeval,
-      skipactivate: skipactivate,
-      variadic: variadic,
-      optional: optional,
-      convert: convert,
+      name: name,
+      debugName: s,
+      typeString: lexed.typeString,
+      type: typeUnionOf(lexed.types),
+      skipeval: lexed.skipeval,
+      skipactivate: lexed.skipactivate,
+      variadic: lexed.variadic,
+      optional: lexed.optional,
+      convert: lexed.convert,
     };
   }
 
@@ -165,60 +121,6 @@ class ParamParser {
   //     }
   //   }
 
-  getTypeValidator(typeString) {
-    let r = "*";
-    for (let i = 0; i < typeString.length; i++) {
-      let typechar = typeString.charAt(i);
-      let type = "";
-      switch (typechar) {
-        case "!":
-          type = "Bool";
-          break;
-        case "~":
-          type = "Command";
-          break;
-        case "*":
-          type = "Deferred";
-          break;
-        case "(":
-          type = "NexContainer";
-          break;
-        case "$":
-          type = "EString";
-          break;
-        case "@":
-          type = "ESymbol";
-          break;
-        case "%":
-          type = "Float";
-          break;
-        case "#":
-          type = "Integer";
-          break;
-        case "_":
-          type = "Wavetable";
-          break;
-        case "^":
-          type = "Instantiator";
-          break;
-        case "&":
-          type = "Closure";
-          break;
-        case "к":
-          type = "Contract";
-          break;
-      }
-      if (r == "*") {
-        r = type;
-      } else {
-        r = r + "|" + type;
-      }
-      if (typechar == "(") {
-        i++;
-      }
-    }
-    return r;
-  }
 }
 
 export { ParamParser };


### PR DESCRIPTION
Stacked on #396.

The grammar is regular — nothing nests, nothing recurses — so `paramlexer.js` is a
lexer with no parser to go with it:

```
param := '_'? '='? name? type* '?'? '...'?
```

The type section is a union built one token at a time, which is why `#%` means
integer or float. It is unordered and repeats are harmless. Only `()` is two
characters, which is what the old `i++` was for.

Underscore is three things at once — the skipeval prefix, a legal character inside
a name, and the wavetable type — and position tells them apart. A name may contain
an underscore but may not end in one, and that rule is what makes `_wt_` come out
as skipeval, name `wt`, type `Wavetable`.

**Every character now has to be claimed by a rule.** One that matches nothing used
to become an empty union member: `"zz"` parsed to `"|"`, which matches nothing and
complains about nothing. For a builtin that is now thrown at startup, because a
builtin's spec is a constant in this source — a typo in one should be loud and
immediate. A lambda's arg list is typed by a person and is half-finished most of
the time, so that path still just says no for now, as before.

**Verified against all 152 argument specs in the codebase**, old parser versus new
lexer: identical on 151. The one difference is the intended kappa change.

Also here:

- **`Clip` gets a validator and the letter `μ`.** This is what let a nil reach
  `play` and be read as a channel number — `play` had to be declared untyped
  because a clip could not be named. It is now
  `channelsorclip#%()μ?`, and `toggle-playback` and `is-playing` are `clipμ`.
  The evaluator rejects a nil before the builtin runs.
- **Contract moves from Cyrillic `к` to Greek `κ`.** Different codepoints, so this
  is a migration: a saved lambda whose arg string contains the old `к` will now be
  rejected by that argument rather than silently matching. Only `contractκ` in
  `contractbuiltins.js` used it in this codebase.
- **`checkType` no longer calls an unknown validator as `undefined`.** Unreachable
  now that specs are strict, but it was a raw TypeError escaping the evaluator.

Confirmed the app still boots — strict specs mean one bad one would break startup,
so that mattered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT