### PR TITLE
[56] Keep nothing on a hosted vodka

### DIFF
--- a/server/runserver.sh
+++ b/server/runserver.sh
@@ -29,4 +29,6 @@ USAGE
 fi
 
 
-node webserver.js
+# Running it yourself means it is yours to save into. A deployed vodka leaves
+# this unset and keeps nothing -- see writesAllowed in webserver.js.
+VODKA_WEBENV="${VODKA_WEBENV:-local}" node webserver.js

--- a/server/webserver.js
+++ b/server/webserver.js
@@ -110,6 +110,11 @@ async function processRequest(req, resp) {
 
 
 	} else if (query.copy) {
+		if (!writesAllowed()) {
+			sendResponse(resp, 403, 'text/html',
+					'this vodka does not keep files, so there is nothing to copy.', 'ERROR');
+			return;
+		}
 		let sessionId = query.sessionId || sessionIdFromCookie;
 		let readonly = (query.type == 'readonly');
 		if (!sessionId) {
@@ -339,6 +344,18 @@ async function loadWebEnv() {
 			? setLocalWebEnv()
 			: setRemoteWebEnv();
 	
+	/*
+	Remote is the default, and a missing or unreadable webenv.txt stays remote.
+	A server that has lost its configuration should refuse to keep files rather
+	than start keeping them, so the safe answer is the one you get by accident.
+
+	Local has to be asked for: runserver.sh sets VODKA_WEBENV, and webenv.txt
+	still works for anyone who was already using it.
+	*/
+	if (process.env.VODKA_WEBENV) {
+		setWebEnv(process.env.VODKA_WEBENV.trim());
+		return;
+	}
 	try {
 		const data = await fsPromises.readFile('webenv.txt');
 		setWebEnv(String(data).trim());
@@ -408,7 +425,9 @@ async function serviceApiRequest(sessionId, resp, data) {
 		arg = data.substr(i + 1);
 	}
 	let respData = `v2:?"unknown api method. Sorry!"`;
-	if (opcode == 'save') {
+	if ((opcode == 'save' || opcode == 'saveraw') && !writesAllowed()) {
+		respData = `v2:?"this vodka does not keep files, your work is in this browser. Sorry!"`;
+	} else if (opcode == 'save') {
 		respData = await serviceApiSaveRequest(arg, sessionId);
 	} else if (opcode == 'load') {
 		respData = await serviceApiLoadRequestUserSession(arg, sessionId, true /*fallback to user session*/);
@@ -443,6 +462,21 @@ isGeneratedSessionId only looks at the prefix, so a generated id needs checking
 too -- the prefix says where the directory lives, not that the rest of the name
 is safe.
 */
+/*
+Nothing a visitor makes is kept on a hosted vodka. Documents and samples live in
+the browser, which is where they already live between reloads, and the server
+serves the app and the shipped libraries and nothing else.
+
+This is decided here rather than by leaving the save button out of the page: the
+api is a post anyone can make by hand, so hiding the button would be a promise
+about the client rather than a property of the server.
+
+Run it on your own machine and it saves as it always has.
+*/
+function writesAllowed() {
+	return webenv_vars.isLocal;
+}
+
 function isLegalSessionId(sessionId) {
 	return typeof sessionId === 'string' && /^[a-zA-Z0-9_-]+$/.test(sessionId);
 }


### PR DESCRIPTION
Stacked on #400, and only safe to deploy together with it.

**vodka.dev keeps nothing.** Documents and samples already survive a reload in
localStorage and IndexedDB, so a deployed vodka serves the app and the shipped
libraries and stores nothing a visitor makes. Clone it and run it on your own
machine and saving works exactly as it does today.

That answers the hosting question rather than managing it: no user content on
disk means no illegal content exposure, no DMCA agent, no takedown process, no
size caps to get right, no stored XSS, no session enumeration, and no logs tying
people to uploads.

**Enforced in the server, not the page.** The api is a POST anyone can make by
hand, so leaving the save button out would be a promise about the client rather
than a property of the server. `save` and `saveraw` are refused when not local,
and so is `?copy`, which writes a whole session.

Reads are untouched — `load`, `listfiles`, `listaudio` and the standard function
libraries all still work, which is what the shipped demo sessions need.

**The default fails closed.** Remote was already the default and a missing
`webenv.txt` already meant remote; that is now load-bearing, so a server that has
lost its configuration refuses to keep files rather than quietly starting to.

Local therefore has to be asked for. `VODKA_WEBENV` is checked first and
`runserver.sh` sets it to `local`, so a fresh clone saves out of the box —
`webenv.txt` is gitignored, so without this a clone would have defaulted to
remote and been unable to save anything.

| | writes |
|---|---|
| `VODKA_WEBENV=local` | yes |
| `VODKA_WEBENV=remote` | no |
| unset, `webenv.txt` says local | yes |
| unset, no file | **no** |

Sharing is deliberately not solved here. When it comes up, the thing to remember
is `run-js` (`syscalls.js:226`): a document that arrives from a link is code, and
it would run on your origin with access to every visitor's stored work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT