### PR TITLE
[58] Let the same client run from a static host or from the vodka server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ server/dist/
 testing/alltests/*/goldens/*/*.backup.png
 .venv-audio/
 tools/soundcatalog/out/embeddings.npz
+server/static/

--- a/server/build.sh
+++ b/server/build.sh
@@ -46,15 +46,19 @@ while [ "$1" != "" ]; do
 		--quiet)
 			LOG_ARGS="--log-level=error"
 			;;
+		--static)
+			MAKE_STATIC=1
+			;;
 		--help|-h)
 			cat <<'USAGE'
-usage: ./build.sh [--dev|--watch] [--quiet]
+usage: ./build.sh [--dev|--watch] [--quiet] [--static]
 
 Bundles the vodka client into server/dist/.
 
   --dev     unminified, with sourcemaps
   --watch   unminified, rebuild on change
   --quiet   report errors only, not warnings
+  --static  also write server/static/, a folder any web server can serve
   --help    this message
 
 Writing to server/dist/ changes what the running server serves, immediately.
@@ -66,7 +70,7 @@ USAGE
 			;;
 		*)
 			echo "build.sh: unknown option '$1'"
-			echo "usage: ./build.sh [--dev|--watch] [--quiet]"
+			echo "usage: ./build.sh [--dev|--watch] [--quiet] [--static]"
 			exit 1
 			;;
 	esac
@@ -94,3 +98,7 @@ npx esbuild src/vodkastart.js \
 
 echo "vodka build: done. Files written:"
 ls -lh dist | tail -n +2 | awk '{ printf "vodka build:   %-28s %s\n", $9, $5 }'
+
+if [ "$MAKE_STATIC" = "1" ]; then
+	node tools/makestatic.js ./static
+fi

--- a/server/src/components/welcome_panel.jsx
+++ b/server/src/components/welcome_panel.jsx
@@ -88,14 +88,14 @@ const WelcomePanel = () => {
                 change computers, change browsers,
                 etc. To export this session to a file that you can import to another browser, <a href="#" onClick={doExport}>click here</a>.
                 To import a session you saved to a file previously, <a href="#" onClick={doImport}>click here</a>.
-                You bookmark <a id="sessionlink" href={buildURL({ "sessionId": sessionId })}>this link</a>
+                Bookmark <a id="sessionlink" href={buildURL({ "sessionId": sessionId })}>this link</a>
                 &nbsp;to come directly back to this session.</p>
             {message && <p className="infoline sessionmessage">{message}</p>}
             <p className="infoline">
                 To create a new session, <a href="#" onClick={askForNewSession}>click here</a>. To make a duplicate of this session, <a href="#" onClick={askForDuplicate}>click here</a>. Saving and loading files is disabled
                 on the web. If you clone the vodka repo and run a local server, you can save files
                 within your session.</p>
-            <p className="infoline">To switch to {oppositeTheme} theme, click <a id="switchthemelink" href={buildURL({ "theme": oppositeTheme })}>here</a></p>
+            <p className="infoline">To switch to {oppositeTheme} theme, click <a id="switchthemelink" href={buildURL({ "theme": oppositeTheme })}>here</a>.</p>
             <p className="infospacer"></p>
             <p className="infoline">Vodka is in beta and is a part-time side project.
                 I will <b>do my best</b> to make sure your session data is preserved across product

--- a/server/src/deployment.js
+++ b/server/src/deployment.js
@@ -1,0 +1,51 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+What kind of thing is serving this. One bundle runs both ways: from the vodka
+server, where it can save and where directories can be listed as they are now,
+and from any static host, where it cannot save and reads a list written at build
+time.
+
+The client is told rather than built twice, so the same dist/ works either way
+and the deployment decides. A missing config.json means a static host that was
+given only the bundle, which is the safe reading: no saving.
+*/
+
+let config = {
+	canSave: false,
+	liveIndex: false,
+};
+
+function loadDeploymentConfig() {
+	return fetch('config.json')
+		.then(function (r) { return r.ok ? r.json() : null; })
+		.then(function (c) { if (c) config = c; })
+		.catch(function () { /* no config, stay static */ });
+}
+
+function canSave() {
+	return !!config.canSave;
+}
+
+// A live server can read its own directory, so a file you add while working
+// shows up without a rebuild. A static host has to be told at build time.
+function hasLiveIndex() {
+	return !!config.liveIndex;
+}
+
+export { loadDeploymentConfig, canSave, hasLiveIndex }

--- a/server/src/servercommunication.js
+++ b/server/src/servercommunication.js
@@ -22,6 +22,7 @@ import { constructFatalError } from './nex/eerror.js'
 import { evaluateNexSafely } from './evaluator.js'
 import { parse } from './nexparser2.js';
 import { AudioCollector, encode as encodeContainer, decode as decodeContainer } from './audiocontainer.js';
+import { hasLiveIndex } from './deployment.js';
 import { SerializationContext, SERIALIZE_FILE } from './serializationcontext.js'
 import { systemState } from './systemstate.js'
 
@@ -64,7 +65,47 @@ function sendToServer(payload, cb, errcb) {
 	}
 }
 
+/*
+Reading a file that ships with the app is a plain GET, so it works the same
+whether the vodka server is answering or a static host is. Only writes still
+need the api, and only the vodka server allows those.
+*/
+function fetchShippedFile(name) {
+	return fetch('packages/' + encodeURIComponent(name)).then(function (r) {
+		if (!r.ok) throw new Error('not found');
+		return r.text();
+	});
+}
+
+/*
+A live server reads its own directory, so a file added while you work shows up
+without a rebuild. A static host was given the list at build time.
+*/
+function fetchIndex(which) {
+	return fetch(which + '/index.json').then(function (r) {
+		if (!r.ok) throw new Error('no index');
+		return r.json();
+	});
+}
+
+function namesToOrgPayload(names) {
+	let quoted = names.map(function (n) { return '"' + n + '"'; }).join(' ');
+	return 'v2:(| ' + quoted + ' |)';
+}
+
+function listFromIndex(which, callback) {
+	fetchIndex(which).then(function (names) {
+		parseReturnPayload(namesToOrgPayload(names), callback);
+	}).catch(function () {
+		callback(serverError());
+	});
+}
+
 function listFiles(callback) {
+	if (!hasLiveIndex()) {
+		listFromIndex('packages', callback);
+		return;
+	}
 	let payload = `listfiles`;
 
 	sendToServer(payload, function(data) {
@@ -75,6 +116,10 @@ function listFiles(callback) {
 }
 
 function listAudio(callback) {
+	if (!hasLiveIndex()) {
+		listFromIndex('sounds', callback);
+		return;
+	}
 	let payload = `listaudio`;
 
 	sendToServer(payload, function(data) {
@@ -86,6 +131,10 @@ function listAudio(callback) {
 
 
 function listStandardFunctionFiles(callback) {
+	if (!hasLiveIndex()) {
+		listFromIndex('packages', callback);
+		return;
+	}
 	let payload = `liststandardfunctionfiles`;
 
 	sendToServer(payload, function(data) {
@@ -97,6 +146,16 @@ function listStandardFunctionFiles(callback) {
 
 
 function loadNex(name, callback) {
+	if (!hasLiveIndex()) {
+		fetchShippedFile(name).then(function (text) {
+			document.title = name;
+			systemState.setDefaultFileName(name);
+			parseReturnPayload(text, callback);
+		}).catch(function () {
+			callback(serverError());
+		});
+		return;
+	}
 	let payload = `load\t${name}`;
 
 	sendToServer(payload, function(data) {
@@ -156,6 +215,16 @@ function importNex(name, callback) {
 }
 
 function loadAndRun(name, callback) {
+	if (!hasLiveIndex()) {
+		fetchShippedFile(name).then(function (text) {
+			parseReturnPayload(text, function (parsed) {
+				callback(evaluateNexSafely(parsed, BINDINGS));
+			});
+		}).catch(function () {
+			callback(serverError());
+		});
+		return;
+	}
 	let payload = `load\t${name}`;
 
 	sendToServer(payload, function(data) {

--- a/server/src/vodka.js
+++ b/server/src/vodka.js
@@ -46,6 +46,8 @@ import { createWavetableBuiltins } from './builtins/wavetablebuiltins.js'
 import { createWaveMathBuiltins } from './builtins/wavemathbuiltins.js'
 import { createMidiBuiltins } from './builtins/midibuiltins.js'
 import { loadAndRun } from './servercommunication.js'
+import { newSessionId } from './sessionmanager.js'
+import { loadDeploymentConfig } from './deployment.js'
 import { RenderNode } from './rendernode.js'
 import { Root } from './nex/root.js'
 import { Command } from './nex/command.js'
@@ -216,6 +218,25 @@ function setOrCreateSessionId() {
 	} else {
 		sessionId = Utils.getCookie('sessionId');
 	}
+	/*
+	Nothing else is going to make one. A static host has no server to mint an id
+	and redirect, and the vodka server no longer needs to either -- a session
+	only exists in the browser, so the browser is the right place to name it.
+
+	Put into the address bar without navigating, so the url is still the way
+	back to this session.
+	*/
+	if (!sessionId) {
+		sessionId = newSessionId();
+		Utils.setCookie('sessionId', sessionId);
+		try {
+			let url = new URL(window.location.href);
+			url.searchParams.set('sessionId', sessionId);
+			window.history.replaceState(null, '', url.toString());
+		} catch (e) {
+			// an address bar we cannot rewrite is not worth failing over
+		}
+	}
 	systemState.setSessionId(sessionId);
 }
 
@@ -270,6 +291,8 @@ function installTestHooks() {
 // lookup and nothing downstream knows storage was involved. Nothing waits on
 // setup()'s return; vodkastart.js calls it at module top level.
 async function setup() {
+	// before anything asks whether it can save or how to list a directory
+	await loadDeploymentConfig();
 	setAppFlags();
 	suppressAnimationsIfRequested();
 	installTestHooks();

--- a/server/tools/makestatic.js
+++ b/server/tools/makestatic.js
@@ -1,0 +1,79 @@
+/*
+This file is part of Vodka.
+
+Vodka is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Vodka is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Vodka.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/*
+Builds the folder you can drop on any static host. No node process, nothing to
+keep running, nothing to patch.
+
+It is the same client bundle the vodka server serves; what differs is the three
+files written here. config.json says there is no saving and no live directory
+listing, and the two index.json files are the directory listings a static host
+cannot produce for itself.
+*/
+
+const fs = require('fs');
+const path = require('path');
+
+const OUT = process.argv[2] ? process.argv[2] : './static';
+const SERVER_DIR = path.join(__dirname, '..');
+
+function copyDir(from, to) {
+	fs.mkdirSync(to, { recursive: true });
+	for (const entry of fs.readdirSync(from, { withFileTypes: true })) {
+		const src = path.join(from, entry.name);
+		const dst = path.join(to, entry.name);
+		if (entry.isDirectory()) {
+			copyDir(src, dst);
+		} else {
+			fs.copyFileSync(src, dst);
+		}
+	}
+}
+
+function main() {
+	const out = path.resolve(OUT);
+	fs.rmSync(out, { recursive: true, force: true });
+	fs.mkdirSync(out, { recursive: true });
+
+	// the app itself
+	copyDir(path.join(SERVER_DIR, 'dist'), path.join(out, 'dist'));
+	copyDir(path.join(SERVER_DIR, 'src', 'css'), path.join(out, 'css'));
+	copyDir(path.join(SERVER_DIR, 'packages'), path.join(out, 'packages'));
+	copyDir(path.join(SERVER_DIR, 'sounds'), path.join(out, 'sounds'));
+
+	// host.html is served as / by the vodka server, and index.html is what a
+	// static host looks for
+	fs.copyFileSync(path.join(SERVER_DIR, 'src', 'host.html'),
+			path.join(out, 'index.html'));
+
+	fs.writeFileSync(path.join(out, 'config.json'), JSON.stringify({
+		canSave: false,
+		liveIndex: false,
+	}, null, 1) + '\n');
+
+	for (const dir of ['packages', 'sounds']) {
+		const names = fs.readdirSync(path.join(SERVER_DIR, dir));
+		fs.writeFileSync(path.join(out, dir, 'index.json'),
+				JSON.stringify(names, null, 1) + '\n');
+		console.log('makestatic: ' + dir + '/index.json lists ' + names.length + ' entries');
+	}
+
+	console.log('makestatic: wrote ' + out);
+	console.log('makestatic: serve that folder with anything -- no vodka server needed');
+}
+
+main();

--- a/server/webserver.js
+++ b/server/webserver.js
@@ -77,6 +77,34 @@ async function processRequest(req, resp) {
 
 	let sessionIdFromCookie = getSessionIdFromCookie(req);
 
+	/*
+	Told to the client rather than compiled into it, so one bundle works both
+	ways: served from here it can save, dropped on a static host it cannot.
+	The static build ships these same three files, which is why the client has
+	no idea which kind of server it is talking to.
+	*/
+	if (parsedUrl.pathname == '/config.json') {
+		sendResponse(resp, 200, 'application/json', JSON.stringify({
+			canSave: writesAllowed(),
+			// a live server can look in the directory, so a file added while
+			// you work shows up without a rebuild
+			liveIndex: true,
+		}), 'config');
+		return;
+	}
+	if (parsedUrl.pathname == '/packages/index.json'
+			|| parsedUrl.pathname == '/sounds/index.json') {
+		let dir = parsedUrl.pathname == '/packages/index.json' ? './packages' : './sounds';
+		let names = [];
+		try {
+			names = fs.readdirSync(dir);
+		} catch (e) {
+			names = [];
+		}
+		sendResponse(resp, 200, 'application/json', JSON.stringify(names), 'index');
+		return;
+	}
+
 	if (isApi) {
 		// the cookie is the fallback for older clients; the session the tab is
 		// actually in comes on the request
@@ -239,6 +267,10 @@ async function serviceRequestForRegularFile(sessionId, path, resp) {
 	// uh
 	let isSessionDownload = false;
 	if (path.indexOf('/sounds') == 0) {
+		path = "." + path;
+	} else if (path.indexOf('/packages/') == 0) {
+		// the shipped library, read the same way a static host would serve it,
+		// so the client has one way of reading a file that ships with the app
 		path = "." + path;
 	} else if (path.indexOf('/dist/') == 0) {
 		// the bundled client, written by build.sh


### PR DESCRIPTION
Stacked on #402.

`./build.sh --static` writes `server/static/` — a folder any web server can serve.
No node process, nothing to keep running, nothing to patch. The vodka server stays
exactly as it is for people who cloned the repo and want to save files, which is
the only thing it is actually needed for.

**One bundle, both ways.** Reading a file that ships with the app is a plain GET
either way: the server already served `sounds/` like that, and now serves
`packages/` the same. Only writes still need the api, and only the vodka server
allows those.

**What differs is three files**, all produced by whichever server is answering:

| | vodka server | static build |
|---|---|---|
| `config.json` | `canSave: true, liveIndex: true` | both false |
| `packages/index.json` | read from the directory, live | written at build time |
| `sounds/index.json` | read from the directory, live | written at build time |

A live server ignores the shipped index and reads its own directory, so a file you
add while working shows up without a rebuild — which matters when the person
running locally is the person adding files.

**Sessions are minted by the browser now** and put into the address bar with
`replaceState`. Nothing else was going to do it: a static host has no server to
redirect, and after #401 a session only exists in the browser anyway. That also
removes the last write a hosted server was doing — every visit used to `mkdir` an
empty session directory that nothing ever wrote to.

## Checked, both ways

**Static**: built the folder, served it with `python3 -m http.server`, no vodka
server running at all. Boots, mints its own session into the url, renders, seven
help tabs, **no failed requests and no page errors**.

**Local**: `VODKA_WEBENV=local` on a spare port. `config.json` answers
`{"canSave":true,"liveIndex":true}`, `packages/index.json` lists the 27 real
directories, boots and renders with no failed requests and no page errors.

## Note

Your copy edits to the welcome panel — "Bookmark" and the trailing full stop — came
in while I was working and are committed here along with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT