### PR TITLE
[59] Do not render the whole document on every click

### DIFF
--- a/server/src/browsereventresponsefunctions.js
+++ b/server/src/browsereventresponsefunctions.js
@@ -61,11 +61,20 @@ function respondToClickEvent(nex, renderNode, atTarget, browserEvent) {
 		}
 
 		browserEvent.stopPropagation();
+		/*
+		setSelected already marks the node losing selection, the node gaining
+		it, and both their parents, and asks for a render of what is dirty.
+		Rendering the whole document on top of that is the cost of every click,
+		and it grows with the size of the document rather than with what
+		changed.
+		*/
 		renderNode.setSelected();
 		if (insertAfterRemove && systemState.getGlobalSelectedNode() != oldSelectedNode) {
+			let wasIn = oldSelectedNode.getParent();
 			manipulator.removeNex(oldSelectedNode);
+			if (wasIn) wasIn.setRenderNodeDirtyForRendering(true);
 		}
-		eventQueueDispatcher.enqueueImportantTopLevelRender();
+		eventQueueDispatcher.enqueueRenderOnlyDirty();
 	}
 }
 


### PR DESCRIPTION
Stacked on #378. Salvaged from the render performance work — the one change of
the three that stands on its own merits.

`setSelected` already marks the node losing selection, the node gaining it, and
both their parents, then asks for a render of what is dirty. The click handler
then called `enqueueImportantTopLevelRender()` on top of that, rendering the
entire document at the highest queue priority. Duplicate work whose cost scales
with the size of the document rather than with what changed.

The multiselect branch still does a full render, since it restructures the
document rather than moving the selection.

**This is not the fix for the 826ms click** — that is issue #399, and it needs
reconciliation rather than trimming. The other two commits from that session
(viewport culling, and letting a dirty nex re-append its children) had no
measurable effect and are deliberately left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT