### PR TITLE
[60] Say out loud when autosave stops

### DIFF
--- a/server/src/autosave.js
+++ b/server/src/autosave.js
@@ -76,6 +76,20 @@ function writeStorage(key, value) {
 		// large enough that we should stop trying rather than retry every edit.
 		console.log('vodka: autosave failed (' + e.name + '), disabling for this session.');
 		disabled = true;
+		/*
+		Said out loud, not only to the console. This is the browser's only copy
+		of the document, so from here on nothing is being kept and reloading
+		loses whatever comes next. Once per session, because `disabled` means
+		we never come back through here.
+		*/
+		try {
+			window.alert('Vodka has stopped saving this session in the browser ('
+					+ e.name + ').\n\nAnything you do from now on will be lost if you '
+					+ 'reload. Export this session to a file from the Welcome tab to '
+					+ 'keep it.');
+		} catch (ignored) {
+			// an alert we cannot show is not worth failing over
+		}
 		return false;
 	}
 }


### PR DESCRIPTION
Stacked on #404. Closes the only part of #405 worth building.

`autosave.js` logged to the console and set `disabled = true`, and nothing in the
interface changed. You would go on working and lose everything after that moment
on reload.

Rare — every package vodka ships adds up to 116k against a budget of about five
megabytes, and samples are in IndexedDB — but the browser is the only copy now, so
the one time it happens is worth interrupting someone for. The alert says what
stopped, that reloading will lose what comes next, and that exporting the session
from the Welcome tab is the way out.

Once per session, since `disabled` means we never come back through that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT