### PR TITLE
Commit imported samples before leaving the page

### DIFF
--- a/server/build.sh
+++ b/server/build.sh
@@ -86,8 +86,11 @@ echo "vodka build: writing bundle to server/dist/"
 rm -rf dist
 mkdir -p dist
 
+BUILD_STAMP="$(git rev-parse --short HEAD 2>/dev/null || echo unknown) built $(date '+%Y-%m-%d %H:%M:%S')"
+
 npx esbuild src/vodkastart.js \
 	--bundle \
+	--define:__VODKA_BUILD__="\"$BUILD_STAMP\"" \
 	--splitting \
 	--format=esm \
 	--outdir=dist \

--- a/server/src/audiostore.js
+++ b/server/src/audiostore.js
@@ -199,14 +199,21 @@ function putForSession(sessionId, hash, buffer) {
 	if (unavailable) return Promise.resolve(false);
 	return openDb().then(function(db) {
 		if (!db) return false;
-		try {
-			let tx = db.transaction(STORE, 'readwrite');
-			tx.objectStore(STORE).put(buffer, sessionId + '/' + hash);
-			return true;
-		} catch (e) {
-			unavailable = true;
-			return false;
-		}
+		return new Promise(function(resolve) {
+			try {
+				let tx = db.transaction(STORE, 'readwrite');
+				tx.objectStore(STORE).put(buffer, sessionId + '/' + hash);
+				// settle on commit, not on queueing the write -- the caller
+				// navigates as soon as this settles, and navigating aborts
+				// any transaction still uncommitted
+				tx.oncomplete = function() { resolve(true); };
+				tx.onabort = function() { resolve(false); };
+				tx.onerror = function() { resolve(false); };
+			} catch (e) {
+				unavailable = true;
+				resolve(false);
+			}
+		});
 	});
 }
 

--- a/server/src/sessionmanager.js
+++ b/server/src/sessionmanager.js
@@ -163,6 +163,7 @@ function exportCurrentSession() {
 	let samples = audioStore.entries().map(function (e) {
 		return { hash: e.hash, samples: toBase64(e.buffer) };
 	});
+	console.log('vodka export: ' + samples.length + ' sample buffer(s) in the file');
 	return {
 		version: FILE_VERSION,
 		kind: 'vodka-session',
@@ -218,7 +219,12 @@ function importSession(parsed) {
 		writes.push(audioStore.putForSession(
 				sessionId, samples[i].hash, fromBase64(samples[i].samples)));
 	}
-	return Promise.all(writes).then(function () { return sessionId; });
+	return Promise.all(writes).then(function (results) {
+		let landed = results.filter(function (ok) { return ok; }).length;
+		console.log('vodka import: ' + landed + ' of ' + samples.length
+				+ ' sample buffer(s) committed');
+		return sessionId;
+	});
 }
 
 // A duplicate is a new session holding the same things, so it gets a new id --

--- a/server/src/vodkastart.js
+++ b/server/src/vodkastart.js
@@ -1,4 +1,9 @@
 import { setup } from './vodka.js'
+
+// stamped by build.sh, so the console says which build this actually is
+console.log('vodka build: '
+		+ (typeof __VODKA_BUILD__ != 'undefined' ? __VODKA_BUILD__ : 'unstamped dev build'));
+
 setup();
 
 // The help system is the one preact island in the project. It's pulled in


### PR DESCRIPTION
An imported session arrived with its document but silent waves. putForSession settled as soon as the IndexedDB write was queued; the import flow navigates to the new session the moment it settles, and navigation aborts an uncommitted transaction. localStorage commits synchronously, IndexedDB doesn't — hence exactly the document surviving and the samples not.

Reproduced the mechanism in isolation (8MB put + immediate navigation → record lost; put + navigate on `oncomplete` → record present, byte-exact). Fix: settle on the transaction's `oncomplete`. Session duplication took the same path and is fixed by the same change.

Note for re-importing tonight: the .vks file you already exported is fine — the samples are in it. Just import it again with this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT