### PR TITLE
Zooming an unedited wave repaints every wavetable

### DIFF
--- a/server/src/nex/wavetable.js
+++ b/server/src/nex/wavetable.js
@@ -146,6 +146,27 @@ function parseInlineSamples(data) {
 
 const DEFAULT_SIZE = 256;
 
+/*
+Zooming while not editing sets the global scale that every non-editing
+wavetable draws at, so all of them have to repaint together or the document
+shows waves at unrelated scales.
+*/
+function renderAllWavetables() {
+	let root = systemState.getRoot();
+	if (!root) return;
+	dirtyWavetablesUnder(root);
+	eventQueueDispatcher.enqueueRenderOnlyDirty();
+}
+
+function dirtyWavetablesUnder(renderNode) {
+	if (renderNode.getNex() instanceof Wavetable) {
+		renderNode.setRenderNodeDirtyForRendering(true);
+	}
+	for (let i = 0; i < renderNode.numChildren(); i++) {
+		dirtyWavetablesUnder(renderNode.getChildAt(i));
+	}
+}
+
 class Wavetable extends Nex {
 	constructor(initSize) {
 		super();
@@ -322,6 +343,7 @@ class Wavetable extends Nex {
 			this.localPixelsPerSample = val;
 		} else {
 			setGlobalPixelsPerSample(val);
+			renderAllWavetables();
 		}
 	}
 
@@ -338,6 +360,7 @@ class Wavetable extends Nex {
 			this.localHeightPixelsFullScale = val;
 		} else {
 			setGlobalHeightPixelsFullScale(val);
+			renderAllWavetables();
 		}
 	}
 


### PR DESCRIPTION
Non-editing zoom writes the global pixels-per-sample / height scale that every non-editing wavetable draws at — the old whole-document render is what kept them visually in sync. The fix hooks the global branch of setPixelsPerSample/setHeightPixelsFullScale: dirty every wavetable render node and render once. Editing zoom is local to the wave (localPixelsPerSample) and still repaints only that wave.

Noted while here: the wavetable manipulator panel (wtmanip showManipulator) is dead code — it calls wt.getHorizZoomListener()/getHorizScrollListener(), which don't exist anywhere. Left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176ZYPTqPjehJmyAwRBwgrT